### PR TITLE
Add config of list indent size

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ disabled:
 
   Whether cljstyle should correct the indentation of your code.
 
+* `:list-indent-size`
+
+  Control indent size of list. The default is 2 spaces. If this setting is 1,
+  lists are formatted as follows.
+```clojure
+(foo
+ bar
+ baz)
+```
+
 * `:line-break-functions?`
 
   Whether cljstyle should enforce line breaks in function definitions.
@@ -216,17 +226,6 @@ disabled:
 
   Require all files to end with a newline character. One will be added if it is
   not present.
-
-* `:list-indent-size`
-
-  Control indent size of list. The default is 2 spaces. If this setting is 1,
-  lists are formatted as follows.
-```clojure
-(foo
- bar
- baz)
-```
-
 
 ### Indentation rules
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ disabled:
   Require all files to end with a newline character. One will be added if it is
   not present.
 
+* `:list-indent-size`
+
+  Control indent size of list. The default is 2 spaces. If this setting is 1,
+  lists are formatted as follows.
+```clojure
+(foo
+ bar
+ baz)
+```
+
+
 ### Indentation rules
 
 There are a few types of indentation rules that can be applied to forms. These

--- a/core/src/cljstyle/config.clj
+++ b/core/src/cljstyle/config.clj
@@ -23,6 +23,7 @@
 
 ;; Formatting Rules
 (s/def ::indentation? boolean?)
+(s/def ::list-indent-size nat-int?)
 (s/def ::line-break-functions? boolean?)
 (s/def ::remove-surrounding-whitespace? boolean?)
 (s/def ::remove-trailing-whitespace? boolean?)
@@ -77,6 +78,7 @@
                    ::single-import-break-width
                    ::require-eof-newline?
                    ::indents
+                   ::list-indent-size
                    ::file-pattern
                    ::file-ignore]))
 
@@ -103,6 +105,7 @@
    :single-import-break-width 30
    :require-eof-newline? true
    :indents default-indents
+   :list-indent-size 2
    :file-pattern #"\.clj[csx]?$"
    :file-ignore #{}})
 

--- a/core/src/cljstyle/config.clj
+++ b/core/src/cljstyle/config.clj
@@ -93,6 +93,7 @@
 
 (def default-config
   {:indentation? true
+   :list-indent-size 2
    :line-break-functions? true
    :remove-surrounding-whitespace? true
    :remove-trailing-whitespace? true
@@ -105,7 +106,6 @@
    :single-import-break-width 30
    :require-eof-newline? true
    :indents default-indents
-   :list-indent-size 2
    :file-pattern #"\.clj[csx]?$"
    :file-ignore #{}})
 

--- a/core/src/cljstyle/format/core.clj
+++ b/core/src/cljstyle/format/core.clj
@@ -271,8 +271,8 @@
 
 (defn- indent-line
   "Apply indentation to the line beginning at this location."
-  [zloc indents list-indent-size]
-  (let [width (indent/indent-amount zloc indents list-indent-size)]
+  [zloc list-indent-size indents]
+  (let [width (indent/indent-amount zloc list-indent-size indents)]
     (if (pos? width)
       (zip/insert-right zloc (whitespace width))
       zloc)))
@@ -280,14 +280,14 @@
 
 (defn indent
   "Transform this form by indenting all lines their proper amounts."
-  [form indents list-indent-size]
-  (transform form edit-all indent/should-indent? #(indent-line % indents list-indent-size)))
+  [form list-indent-size indents]
+  (transform form edit-all indent/should-indent? #(indent-line % list-indent-size indents)))
 
 
 (defn reindent
   "Transform this form by rewriting all line indentation."
-  [form indents list-indent-size]
-  (indent (unindent form) indents list-indent-size))
+  [form list-indent-size indents]
+  (indent (unindent form) list-indent-size indents))
 
 
 
@@ -346,7 +346,7 @@
     (insert-padding-lines (:padding-lines config 2))
 
     (:indentation? config true)
-    (reindent (:indents config config/default-indents) (:list-indent-size config 2))
+    (reindent (:list-indent-size config 2) (:indents config config/default-indents))
 
     (:rewrite-namespaces? config true)
     (rewrite-namespaces config)

--- a/core/src/cljstyle/format/core.clj
+++ b/core/src/cljstyle/format/core.clj
@@ -271,8 +271,8 @@
 
 (defn- indent-line
   "Apply indentation to the line beginning at this location."
-  [zloc indents]
-  (let [width (indent/indent-amount zloc indents)]
+  [zloc indents list-indent-size]
+  (let [width (indent/indent-amount zloc indents list-indent-size)]
     (if (pos? width)
       (zip/insert-right zloc (whitespace width))
       zloc)))
@@ -280,14 +280,14 @@
 
 (defn indent
   "Transform this form by indenting all lines their proper amounts."
-  [form indents]
-  (transform form edit-all indent/should-indent? #(indent-line % indents)))
+  [form indents list-indent-size]
+  (transform form edit-all indent/should-indent? #(indent-line % indents list-indent-size)))
 
 
 (defn reindent
   "Transform this form by rewriting all line indentation."
-  [form indents]
-  (indent (unindent form) indents))
+  [form indents list-indent-size]
+  (indent (unindent form) indents list-indent-size))
 
 
 
@@ -346,7 +346,7 @@
     (insert-padding-lines (:padding-lines config 2))
 
     (:indentation? config true)
-    (reindent (:indents config config/default-indents))
+    (reindent (:indents config config/default-indents) (:list-indent-size config 2))
 
     (:rewrite-namespaces? config true)
     (rewrite-namespaces config)

--- a/core/test/cljstyle/format/indent_test.clj
+++ b/core/test/cljstyle/format/indent_test.clj
@@ -7,24 +7,33 @@
 
 (defn reindent-string
   ([form-string]
-   (reindent-string form-string config/default-indents))
-  ([form-string indents]
+   (reindent-string form-string 2 config/default-indents))
+  ([form-string list-indent-size]
+   (reindent-string form-string list-indent-size config/default-indents))
+  ([form-string list-indent-size indents]
    (reformat-string form-string {:indentation? true
-                                 :indents indents})))
+                                 :indents indents
+                                 :list-indent-size list-indent-size})))
 
 
 (deftest list-indentation
   (is (= "(foo bar\n     baz\n     quz)"
          (reindent-string "(foo bar\nbaz\nquz)")))
   (is (= "(foo\n  bar\n  baz)"
-         (reindent-string "(foo\n bar\nbaz)"))))
+         (reindent-string "(foo\n bar\nbaz)")))
+  (is (= "(foo\n bar\n baz)"
+         (reindent-string "(foo\n  bar\nbaz)" 1))))
 
 
 (deftest block-indentation
   (is (= "(if (= x 1)\n  :foo\n  :bar)"
          (reindent-string "(if (= x 1)\n:foo\n:bar)")))
+  (is (= "(if (= x 1)\n  :foo\n  :bar)"
+         (reindent-string "(if (= x 1)\n:foo\n:bar)" 1)))
   (is (= "(do\n  (foo)\n  (bar))"
          (reindent-string "(do\n(foo)\n(bar))")))
+  (is (= "(do\n  (foo)\n  (bar))"
+         (reindent-string "(do\n(foo)\n(bar))" 1)))
   (is (= "(do (foo)\n    (bar))"
          (reindent-string "(do (foo)\n(bar))")))
   (is (= "(deftype Foo\n  [x]\n  Bar)"
@@ -34,24 +43,35 @@
 (deftest stair-indentation
   (is (= "(cond\n  a? a\n  b? b)"
          (reindent-string "(cond  \na? a\n   b? b)"
+                          2
                           {'cond [[:stair 0]]})))
   (is (= "(cond\n  a?\n    a\n  b?\n    b)"
          (reindent-string "(cond  \na?\n a\nb?\n  b)"
+                          2
+                          {'cond [[:stair 0]]})))
+  (is (= "(cond\n  a?\n    a\n  b?\n    b)"
+         (reindent-string "(cond  \na?\n a\nb?\n  b)"
+                          1
                           {'cond [[:stair 0]]})))
   (is (= "(condp = (:k x)\n  a?\n    a\n  b?\n    b)"
          (reindent-string "(condp = (:k x)\n a?\n a\nb?\n      b)"
+                          2
                           {'condp [[:stair 2]]})))
   (is (= "(cond->\n  a? (a 123)\n  b? (b true))"
          (reindent-string "(cond->  \n  a? (a 123)\n  b? (b true))"
+                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond->\n  a?\n    (a 123)\n  b?\n    (b true))"
          (reindent-string "(cond->\n  a?\n(a 123)\n  b?\n(b true))"
+                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond-> x\n  a?\n    (a 123)\n  b?\n    (b true))"
          (reindent-string "(cond-> x \n  a?\n(a 123)\n  b?\n(b true))"
+                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond->> x\n  a? a\n  b? b)"
          (reindent-string "(cond->> x\na? a\nb? b)"
+                          2
                           {'cond->> [[:stair 1]]}))))
 
 
@@ -73,6 +93,8 @@
 (deftest inner-indentation
   (is (= "(letfn [(foo\n          [x]\n          (* x x))]\n  (foo 5))"
          (reindent-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))")))
+  (is (= "(letfn [(foo\n          [x]\n          (* x x))]\n  (foo 5))"
+         (reindent-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))" 1)))
   (is (= "(reify Closeable\n  (close [_]\n    (prn :closed)))"
          (reindent-string "(reify Closeable\n(close [_]\n(prn :closed)))")))
   (is (= "(defrecord Foo\n  [x]\n  Closeable\n  (close [_]\n    (prn x)))"
@@ -96,4 +118,6 @@
   (is (= "(let [foo\n      {:x 1\n       :y 2}]  (:x foo))"
          (reindent-string "(let [foo\n{:x 1\n:y 2}]  (:x foo))")))
   (is (= "(if foo\n  (do bar\n      baz)\n  quz)"
-         (reindent-string "(if foo\n(do bar\nbaz)\nquz)"))))
+         (reindent-string "(if foo\n(do bar\nbaz)\nquz)")))
+  (is (= "(if foo\n  (do bar\n      baz)\n  (quz\n   foo\n   bar))"
+         (reindent-string "(if foo\n(do bar\nbaz)\n(quz  \n  foo\nbar))" 1))))

--- a/core/test/cljstyle/format/indent_test.clj
+++ b/core/test/cljstyle/format/indent_test.clj
@@ -7,10 +7,10 @@
 
 (defn reindent-string
   ([form-string]
-   (reindent-string form-string 2 config/default-indents))
-  ([form-string list-indent-size]
-   (reindent-string form-string list-indent-size config/default-indents))
-  ([form-string list-indent-size indents]
+   (reindent-string form-string config/default-indents 2))
+  ([form-string indents]
+   (reindent-string form-string indents 2))
+  ([form-string indents list-indent-size]
    (reformat-string form-string {:indentation? true
                                  :indents indents
                                  :list-indent-size list-indent-size})))
@@ -22,18 +22,24 @@
   (is (= "(foo\n  bar\n  baz)"
          (reindent-string "(foo\n bar\nbaz)")))
   (is (= "(foo\n bar\n baz)"
-         (reindent-string "(foo\n  bar\nbaz)" 1))))
+         (reindent-string "(foo\n  bar\nbaz)"
+                          config/default-indents
+                          1))))
 
 
 (deftest block-indentation
   (is (= "(if (= x 1)\n  :foo\n  :bar)"
          (reindent-string "(if (= x 1)\n:foo\n:bar)")))
   (is (= "(if (= x 1)\n  :foo\n  :bar)"
-         (reindent-string "(if (= x 1)\n:foo\n:bar)" 1)))
+         (reindent-string "(if (= x 1)\n:foo\n:bar)"
+                          config/default-indents
+                          1)))
   (is (= "(do\n  (foo)\n  (bar))"
          (reindent-string "(do\n(foo)\n(bar))")))
   (is (= "(do\n  (foo)\n  (bar))"
-         (reindent-string "(do\n(foo)\n(bar))" 1)))
+         (reindent-string "(do\n(foo)\n(bar))"
+                          config/default-indents
+                          1)))
   (is (= "(do (foo)\n    (bar))"
          (reindent-string "(do (foo)\n(bar))")))
   (is (= "(deftype Foo\n  [x]\n  Bar)"
@@ -43,35 +49,28 @@
 (deftest stair-indentation
   (is (= "(cond\n  a? a\n  b? b)"
          (reindent-string "(cond  \na? a\n   b? b)"
-                          2
                           {'cond [[:stair 0]]})))
   (is (= "(cond\n  a?\n    a\n  b?\n    b)"
          (reindent-string "(cond  \na?\n a\nb?\n  b)"
-                          2
                           {'cond [[:stair 0]]})))
   (is (= "(cond\n  a?\n    a\n  b?\n    b)"
          (reindent-string "(cond  \na?\n a\nb?\n  b)"
-                          1
-                          {'cond [[:stair 0]]})))
+                          {'cond [[:stair 0]]}
+                          1)))
   (is (= "(condp = (:k x)\n  a?\n    a\n  b?\n    b)"
          (reindent-string "(condp = (:k x)\n a?\n a\nb?\n      b)"
-                          2
                           {'condp [[:stair 2]]})))
   (is (= "(cond->\n  a? (a 123)\n  b? (b true))"
          (reindent-string "(cond->  \n  a? (a 123)\n  b? (b true))"
-                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond->\n  a?\n    (a 123)\n  b?\n    (b true))"
          (reindent-string "(cond->\n  a?\n(a 123)\n  b?\n(b true))"
-                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond-> x\n  a?\n    (a 123)\n  b?\n    (b true))"
          (reindent-string "(cond-> x \n  a?\n(a 123)\n  b?\n(b true))"
-                          2
                           {'cond-> [[:stair 1]]})))
   (is (= "(cond->> x\n  a? a\n  b? b)"
          (reindent-string "(cond->> x\na? a\nb? b)"
-                          2
                           {'cond->> [[:stair 1]]}))))
 
 
@@ -94,7 +93,9 @@
   (is (= "(letfn [(foo\n          [x]\n          (* x x))]\n  (foo 5))"
          (reindent-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))")))
   (is (= "(letfn [(foo\n          [x]\n          (* x x))]\n  (foo 5))"
-         (reindent-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))" 1)))
+         (reindent-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))"
+                          config/default-indents
+                          1)))
   (is (= "(reify Closeable\n  (close [_]\n    (prn :closed)))"
          (reindent-string "(reify Closeable\n(close [_]\n(prn :closed)))")))
   (is (= "(defrecord Foo\n  [x]\n  Closeable\n  (close [_]\n    (prn x)))"
@@ -120,4 +121,6 @@
   (is (= "(if foo\n  (do bar\n      baz)\n  quz)"
          (reindent-string "(if foo\n(do bar\nbaz)\nquz)")))
   (is (= "(if foo\n  (do bar\n      baz)\n  (quz\n   foo\n   bar))"
-         (reindent-string "(if foo\n(do bar\nbaz)\n(quz  \n  foo\nbar))" 1))))
+         (reindent-string "(if foo\n(do bar\nbaz)\n(quz  \n  foo\nbar))"
+                          config/default-indents
+                          1))))


### PR DESCRIPTION
This PR is related to #8.

Add config of list indent size.
If this config is set to 1. Codes is formatted as below.
```clojure
(foo
 bar
 baz)
```