### PR TITLE
Pipe Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- The `pipe` command will fix any formatting issues reading from stdin and
+  writing to stdout.
 
 
 ## [0.9.0] - 2019-10-13

--- a/README.md
+++ b/README.md
@@ -35,6 +35,39 @@ Releases are published on the [GitHub project](https://github.com/greglook/cljst
 The native binaries are self-contained, so to install them simply place them on
 your path.
 
+## Editor Integration
+
+### Vim
+
+For a simple vim integration copy the following into your `vimrc`
+
+```vimscript
+
+function! Cljstyle()
+    let filename = expand('%:p')
+    let cwd = getcwd()
+    let pos = getpos('.')
+
+    " Change to the directory of the file and run cljstyle
+    let fileDir = strpart(filename, 0, stridx(filename, "/"))
+    execute "cd " . fileDir
+
+    :%!cljstyle pipe
+
+    " Change back to the working directory
+    execute "cd " . cwd
+    call setpos('.', pos)
+
+endfunction
+
+command! Cljstyle :undojoin | call Cljstyle()
+
+```
+
+Calling `Cljstyle` will run `cljstyle pipe` on the current buffer.
+
+You can optionally add `autocmd BufWritePre *.cl* Cljstyle` to auto cljstyle on save.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -44,19 +44,14 @@ For a simple vim integration copy the following into your `vimrc`
 ```vimscript
 
 function! Cljstyle()
-    let filename = expand('%:p')
     let cwd = getcwd()
-    let pos = getpos('.')
-
-    " Change to the directory of the file and run cljstyle
-    let fileDir = strpart(filename, 0, stridx(filename, "/"))
-    execute "cd " . fileDir
+    let winsave = winsaveview()
+    execute "cd" . expand('%:p:h')
 
     :%!cljstyle pipe
 
-    " Change back to the working directory
-    execute "cd " . cwd
-    call setpos('.', pos)
+    execute "cd" . cwd
+    call winrestview(winsave)
 
 endfunction
 

--- a/core/src/cljstyle/task/core.clj
+++ b/core/src/cljstyle/task/core.clj
@@ -146,6 +146,7 @@
     (pprint config)))
 
 
+
 ;; ## Find Command
 
 (defn print-find-usage
@@ -218,6 +219,7 @@
       (p/printerrf "%d files formatted incorrectly" (:incorrect counts))
       (System/exit 2))
     (p/logf "All %d files formatted correctly" (:correct counts))))
+
 
 
 ;; ## Fix Command

--- a/core/src/cljstyle/task/core.clj
+++ b/core/src/cljstyle/task/core.clj
@@ -16,162 +16,101 @@
 ;; ## Utilities
 
 (defn- search-roots
-  "Convert the list of paths into a collection of search
-                    roots. If the path list is empty, uses the local directory
-                    as a single root." [paths]
-  (mapv io/file (or (seq paths)
-                    ["."])))
+  "Convert the list of paths into a collection of search roots. If the path
+  list is empty, uses the local directory as a single root."
+  [paths]
+  (mapv io/file (or (seq paths) ["."])))
 
 
 (defn- load-configs
-  "Load parent configuration files. Returns a merged
-                    configuration map." [label ^File file]
-  (let [configs
-        (config/find-parents file 25)]
-    (if (seq
-          configs) (p/logf "Using cljstyle
-                    configuration from %d sources for %s:\n%s" (count configs)
-                           label (str/join
-                                   "\n" (mapcat
-                                          config/source-paths
-                                          configs)))
-        (p/logf "Using default cljstyle configuration for %s" label)) (apply
-                                                                        config/merge-settings
-                                                                        config/default-config
-                                                                        configs)))
+  "Load parent configuration files. Returns a merged configuration map."
+  [label ^File file]
+  (let [configs (config/find-parents file 25)]
+    (if (seq configs)
+      (p/logf "Using cljstyle configuration from %d sources for %s:\n%s"
+              (count configs)
+              label
+              (str/join "\n" (mapcat config/source-paths configs)))
+      (p/logf "Using default cljstyle configuration for %s"
+              label))
+    (apply config/merge-settings config/default-config configs)))
 
 
 (defn- walk-files!
-  "Walk source files and apply the processing function to
-                    each." [f paths]
-  (->> (search-roots paths) (pmap (fn prep-root
-                                    [^File root]
-                                    (let [canonical
-                                          (.getCanonicalFile root)]
-                                      [(load-configs (.getPath
-                                                       root) canonical) root canonical])))
-       (process/walk-files! f)))
+  "Walk source files and apply the processing function to each."
+  [f paths]
+  (->>
+    (search-roots paths)
+    (pmap (fn prep-root
+            [^File root]
+            (let [canonical (.getCanonicalFile root)]
+              [(load-configs (.getPath root) canonical) root canonical])))
+    (process/walk-files! f)))
 
 
 (defn- write-stats!
   "Write stats output to the named file."
   [file-name stats]
   (let [ext (last (str/split file-name #"\."))]
-    (case ext "edn" (spit file-name
-                          (prn-str
-                            stats))
+    (case ext
+      "edn"
+      (spit file-name (prn-str stats))
 
-          "tsv" (->> (:files stats) (into (dissoc stats :files) (map (fn [[k v]]
-                                                                       [(keyword
-                                                                          "files"
-                                                                          (name k))
-                                                                        v]))) (map
-                                                                                (fn [[k
-                                                                                      v]]
-                                                                                  (str
-                                                                                    (subs
-                                                                                      (str
-                                                                                        k)
-                                                                                      1)
-                                                                                    \tab
-                                                                                    v
-                                                                                    \newline)))
-                     (str/join) (spit file-name))
+      "tsv"
+      (->> (:files stats)
+           (into (dissoc stats :files)
+                 (map (fn [[k v]]
+                        [(keyword "files" (name k)) v])))
+           (map (fn [[k v]] (str (subs (str k) 1) \tab v \newline)))
+           (str/join)
+           (spit file-name))
 
       ;; else
-          (p/printerrf "Unknown stats file extension '%s' - ignoring!" ext))))
+      (p/printerrf "Unknown stats file extension '%s' - ignoring!" ext))))
 
 
 (defn- report-stats
   "General result reporting logic."
   [results]
-  (let [counts
-        (:counts
-          results)
-        total-files
-        (apply +
-               (vals
-                 counts))
-        diff-lines
-        (apply +
-               (keep
-                 :diff-lines
-                 (vals
-                   (:results
-                     results))))
-        stats
-        (cond->
-          {:files
-           counts
-           :total
-           total-files
-           :elapsed
-           (:elapsed
-             results)}
-          (pos?
-            diff-lines)
-          (assoc
-            :diff-lines
-            diff-lines))]
-    (p/logf
-      "Checked %d
-                                                                    files in
-                                                                    %.2f ms"
-      total-files
-      (:elapsed
-        results
-        -1.0))
-    (p/log
-      (pr-str
-        stats))
-    (when-let
-      [stats-file
-       (p/option
-         :stats)]
-      (write-stats!
-        stats-file
-        stats))))
+  (let [counts (:counts results)
+        total-files (apply + (vals counts))
+        diff-lines (apply + (keep :diff-lines (vals (:results results))))
+        stats (cond-> {:files counts
+                       :total total-files
+                       :elapsed (:elapsed results)}
+                (pos? diff-lines)
+                (assoc :diff-lines diff-lines))]
+    (p/logf "Checked %d files in %.2f ms"
+            total-files
+            (:elapsed results -1.0))
+    (p/log (pr-str stats))
+    (when-let [stats-file (p/option :stats)]
+      (write-stats! stats-file stats))))
 
 
 ;; ## Version Command
 
-(def version "Project version string." (if-let [props-file (io/resource
-                                                             "META-INF/maven/mvxcvi/cljstyle/pom.properties")]
-                                         (with-open [props-reader (io/reader
-                                                                    props-file)]
-                                           (let [props (doto
-                                                         (java.util.Properties.)
-                                                         (.load props-reader))
-                                                 {:strs [groupId artifactId
-                                                         version revision]}
-                                                 props] (format "%s/%s %s (%s)"
-                                                                groupId
-                                                                artifactId
-                                                                version
-                                                                (str/trim-newline
-                                                                  revision))))
-                                         "HEAD"))
+(def version
+  "Project version string."
+  (if-let [props-file (io/resource "META-INF/maven/mvxcvi/cljstyle/pom.properties")]
+    (with-open [props-reader (io/reader props-file)]
+      (let [props (doto (java.util.Properties.)
+                    (.load props-reader))
+            {:strs [groupId artifactId version revision]} props]
+        (format "%s/%s %s (%s)"
+                groupId artifactId version
+                (str/trim-newline revision))))
+    "HEAD"))
 
 
 (defn print-version
   "Implementation of the `version` command."
   [args]
-  (when
-    (seq
-      args)
-    (binding
-      [*out*
-       *err*]
-      (println
-        "cljstyle
-                                                                            version
-                                                                            command
-                                                                            takes
-                                                                            no
-                                                                            arguments")
+  (when (seq args)
+    (binding [*out* *err*]
+      (println "cljstyle version command takes no arguments")
       (flush)
-      (System/exit
-        1)))
+      (System/exit 1)))
   (println version)
   (flush))
 

--- a/core/src/cljstyle/task/core.clj
+++ b/core/src/cljstyle/task/core.clj
@@ -16,105 +16,164 @@
 ;; ## Utilities
 
 (defn- search-roots
-  "Convert the list of paths into a collection of search roots. If the path
-  list is empty, uses the local directory as a single root."
-  [paths]
-  (mapv io/file (or (seq paths) ["."])))
+  "Convert the list of paths into a collection of search
+                    roots. If the path list is empty, uses the local directory
+                    as a single root." [paths]
+  (mapv io/file (or (seq paths)
+                    ["."])))
 
 
 (defn- load-configs
-  "Load parent configuration files. Returns a merged configuration map."
-  [label ^File file]
-  (let [configs (config/find-parents file 25)]
-    (if (seq configs)
-      (p/logf "Using cljstyle configuration from %d sources for %s:\n%s"
-              (count configs)
-              label
-              (str/join "\n" (mapcat config/source-paths configs)))
-      (p/logf "Using default cljstyle configuration for %s"
-              label))
-    (apply config/merge-settings config/default-config configs)))
+  "Load parent configuration files. Returns a merged
+                    configuration map." [label ^File file]
+  (let [configs
+        (config/find-parents file 25)]
+    (if (seq
+          configs) (p/logf "Using cljstyle
+                    configuration from %d sources for %s:\n%s" (count configs)
+                           label (str/join
+                                   "\n" (mapcat
+                                          config/source-paths
+                                          configs)))
+        (p/logf "Using default cljstyle configuration for %s" label)) (apply
+                                                                        config/merge-settings
+                                                                        config/default-config
+                                                                        configs)))
 
 
 (defn- walk-files!
-  "Walk source files and apply the processing function to each."
-  [f paths]
-  (->>
-    (search-roots paths)
-    (pmap (fn prep-root
-            [^File root]
-            (let [canonical (.getCanonicalFile root)]
-              [(load-configs (.getPath root) canonical) root canonical])))
-    (process/walk-files! f)))
+  "Walk source files and apply the processing function to
+                    each." [f paths]
+  (->> (search-roots paths) (pmap (fn prep-root
+                                    [^File root]
+                                    (let [canonical
+                                          (.getCanonicalFile root)]
+                                      [(load-configs (.getPath
+                                                       root) canonical) root canonical])))
+       (process/walk-files! f)))
 
 
 (defn- write-stats!
   "Write stats output to the named file."
   [file-name stats]
   (let [ext (last (str/split file-name #"\."))]
-    (case ext
-      "edn"
-      (spit file-name (prn-str stats))
+    (case ext "edn" (spit file-name
+                          (prn-str
+                            stats))
 
-      "tsv"
-      (->> (:files stats)
-           (into (dissoc stats :files)
-                 (map (fn [[k v]]
-                        [(keyword "files" (name k)) v])))
-           (map (fn [[k v]] (str (subs (str k) 1) \tab v \newline)))
-           (str/join)
-           (spit file-name))
+          "tsv" (->> (:files stats) (into (dissoc stats :files) (map (fn [[k v]]
+                                                                       [(keyword
+                                                                          "files"
+                                                                          (name k))
+                                                                        v]))) (map
+                                                                                (fn [[k
+                                                                                      v]]
+                                                                                  (str
+                                                                                    (subs
+                                                                                      (str
+                                                                                        k)
+                                                                                      1)
+                                                                                    \tab
+                                                                                    v
+                                                                                    \newline)))
+                     (str/join) (spit file-name))
 
       ;; else
-      (p/printerrf "Unknown stats file extension '%s' - ignoring!" ext))))
+          (p/printerrf "Unknown stats file extension '%s' - ignoring!" ext))))
 
 
 (defn- report-stats
   "General result reporting logic."
   [results]
-  (let [counts (:counts results)
-        total-files (apply + (vals counts))
-        diff-lines (apply + (keep :diff-lines (vals (:results results))))
-        stats (cond-> {:files counts
-                       :total total-files
-                       :elapsed (:elapsed results)}
-                (pos? diff-lines)
-                (assoc :diff-lines diff-lines))]
-    (p/logf "Checked %d files in %.2f ms"
-            total-files
-            (:elapsed results -1.0))
-    (p/log (pr-str stats))
-    (when-let [stats-file (p/option :stats)]
-      (write-stats! stats-file stats))))
-
+  (let [counts
+        (:counts
+          results)
+        total-files
+        (apply +
+               (vals
+                 counts))
+        diff-lines
+        (apply +
+               (keep
+                 :diff-lines
+                 (vals
+                   (:results
+                     results))))
+        stats
+        (cond->
+          {:files
+           counts
+           :total
+           total-files
+           :elapsed
+           (:elapsed
+             results)}
+          (pos?
+            diff-lines)
+          (assoc
+            :diff-lines
+            diff-lines))]
+    (p/logf
+      "Checked %d
+                                                                    files in
+                                                                    %.2f ms"
+      total-files
+      (:elapsed
+        results
+        -1.0))
+    (p/log
+      (pr-str
+        stats))
+    (when-let
+      [stats-file
+       (p/option
+         :stats)]
+      (write-stats!
+        stats-file
+        stats))))
 
 
 ;; ## Version Command
 
-(def version
-  "Project version string."
-  (if-let [props-file (io/resource "META-INF/maven/mvxcvi/cljstyle/pom.properties")]
-    (with-open [props-reader (io/reader props-file)]
-      (let [props (doto (java.util.Properties.)
-                    (.load props-reader))
-            {:strs [groupId artifactId version revision]} props]
-        (format "%s/%s %s (%s)"
-                groupId artifactId version
-                (str/trim-newline revision))))
-    "HEAD"))
+(def version "Project version string." (if-let [props-file (io/resource
+                                                             "META-INF/maven/mvxcvi/cljstyle/pom.properties")]
+                                         (with-open [props-reader (io/reader
+                                                                    props-file)]
+                                           (let [props (doto
+                                                         (java.util.Properties.)
+                                                         (.load props-reader))
+                                                 {:strs [groupId artifactId
+                                                         version revision]}
+                                                 props] (format "%s/%s %s (%s)"
+                                                                groupId
+                                                                artifactId
+                                                                version
+                                                                (str/trim-newline
+                                                                  revision))))
+                                         "HEAD"))
 
 
 (defn print-version
   "Implementation of the `version` command."
   [args]
-  (when (seq args)
-    (binding [*out* *err*]
-      (println "cljstyle version command takes no arguments")
+  (when
+    (seq
+      args)
+    (binding
+      [*out*
+       *err*]
+      (println
+        "cljstyle
+                                                                            version
+                                                                            command
+                                                                            takes
+                                                                            no
+                                                                            arguments")
       (flush)
-      (System/exit 1)))
+      (System/exit
+        1)))
   (println version)
   (flush))
-
 
 
 ;; ## Config Command
@@ -146,7 +205,6 @@
     (pprint config)))
 
 
-
 ;; ## Find Command
 
 (defn print-find-usage
@@ -175,7 +233,6 @@
             total
             (:elapsed results -1.0))
     (p/log (pr-str counts))))
-
 
 
 ;; ## Check Command
@@ -221,7 +278,6 @@
     (p/logf "All %d files formatted correctly" (:correct counts))))
 
 
-
 ;; ## Fix Command
 
 (defn print-fix-usage
@@ -258,3 +314,22 @@
     (if (zero? (:fixed counts 0))
       (p/logf "All %d files formatted correctly" (:correct counts))
       (p/printerrf "Corrected formatting of %d files" (:fixed counts)))))
+
+
+;; ## Pipe Command
+
+(defn print-pipe-usage
+  "Print help for the `pipe` command."
+  []
+  (println "Usage: cljstyle [options] pipe")
+  (newline)
+  (println "Reads from stdin and fixes formatting errors piping the results to stdout."))
+
+
+(defn pipe
+  "Implementation of the `pipe` command."
+  []
+  (let [cwd ^File (io/file (System/getProperty "user.dir"))
+        config (load-configs (.getPath cwd) cwd)]
+    (print (format/reformat-file (slurp *in*) config))
+    (flush)))

--- a/core/src/cljstyle/task/core.clj
+++ b/core/src/cljstyle/task/core.clj
@@ -88,6 +88,7 @@
       (write-stats! stats-file stats))))
 
 
+
 ;; ## Version Command
 
 (def version
@@ -113,6 +114,7 @@
       (System/exit 1)))
   (println version)
   (flush))
+
 
 
 ;; ## Config Command
@@ -172,6 +174,7 @@
             total
             (:elapsed results -1.0))
     (p/log (pr-str counts))))
+
 
 
 ;; ## Check Command
@@ -255,6 +258,7 @@
       (p/printerrf "Corrected formatting of %d files" (:fixed counts)))))
 
 
+
 ;; ## Pipe Command
 
 (defn print-pipe-usage
@@ -268,7 +272,7 @@
 (defn pipe
   "Implementation of the `pipe` command."
   []
-  (let [cwd ^File (io/file (System/getProperty "user.dir"))
-        config (load-configs (.getPath cwd) cwd)]
+  (let [cwd (System/getProperty "user.dir")
+        config (load-configs cwd (io/file cwd))]
     (print (format/reformat-file (slurp *in*) config))
     (flush)))

--- a/tool/dev/user.clj
+++ b/tool/dev/user.clj
@@ -1,8 +1,7 @@
 (ns user
   (:require
     [cljstyle.config :as config]
-    [cljstyle.core :as cljstyle]
-    [cljstyle.tool.process :as process]
+    [cljstyle.task.process :as process]
     [clojure.java.io :as io]
     [clojure.repl :refer :all]
     [clojure.string :as str]

--- a/tool/dev/user.clj
+++ b/tool/dev/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require
     [cljstyle.config :as config]
+    [cljstyle.task.core :as core]
     [cljstyle.task.process :as process]
     [clojure.java.io :as io]
     [clojure.repl :refer :all]

--- a/tool/src/cljstyle/tool/main.clj
+++ b/tool/src/cljstyle/tool/main.clj
@@ -25,6 +25,7 @@
   (println "    find      Find files which would be processed.")
   (println "    check     Check source files and print a diff for errors.")
   (println "    fix       Edit source files to fix formatting errors.")
+  (println "    pipe      Fixes formatting errors from stdin and pipes the results to stdout.")
   (println "    config    Show config used for a given path.")
   (println "    version   Print program version information.")
   (newline)
@@ -50,6 +51,7 @@
         "find"   (task/print-find-usage)
         "check"  (task/print-check-usage)
         "fix"    (task/print-fix-usage)
+        "pipe"   (task/print-pipe-usage)
         "config" (task/print-config-usage)
         (print-general-usage (parsed :summary)))
       (flush)
@@ -62,14 +64,15 @@
     ;; Execute requested command.
     (try
       (p/with-options options
-        (case command
-          "find"    (task/find-sources args)
-          "check"   (task/check-sources args)
-          "fix"     (task/fix-sources args)
-          "config"  (task/show-config args)
-          "version" (task/print-version args)
-          (do (p/printerr "Unknown cljstyle command:" command)
-              (System/exit 1))))
+                      (case command
+                        "find"    (task/find-sources args)
+                        "check"   (task/check-sources args)
+                        "fix"     (task/fix-sources args)
+                        "config"  (task/show-config args)
+                        "pipe"    (task/pipe)
+                        "version" (task/print-version args)
+                        (do (p/printerr "Unknown cljstyle command:" command)
+                            (System/exit 1))))
       (catch Exception ex
         (binding [*out* *err*]
           (if (= ::config/invalid (:type (ex-data ex)))

--- a/tool/src/cljstyle/tool/main.clj
+++ b/tool/src/cljstyle/tool/main.clj
@@ -64,15 +64,15 @@
     ;; Execute requested command.
     (try
       (p/with-options options
-                      (case command
-                        "find"    (task/find-sources args)
-                        "check"   (task/check-sources args)
-                        "fix"     (task/fix-sources args)
-                        "config"  (task/show-config args)
-                        "pipe"    (task/pipe)
-                        "version" (task/print-version args)
-                        (do (p/printerr "Unknown cljstyle command:" command)
-                            (System/exit 1))))
+        (case command
+          "find"    (task/find-sources args)
+          "check"   (task/check-sources args)
+          "fix"     (task/fix-sources args)
+          "config"  (task/show-config args)
+          "pipe"    (task/pipe)
+          "version" (task/print-version args)
+          (do (p/printerr "Unknown cljstyle command:" command)
+              (System/exit 1))))
       (catch Exception ex
         (binding [*out* *err*]
           (if (= ::config/invalid (:type (ex-data ex)))


### PR DESCRIPTION
Adds the `pipe` command. Which reads from stdin fixing any formatting issues and writes to stdout. Intended for editor integration.

I also added the editor integration section in the README for a simple vim setup.