### PR TITLE
Handle shadow-cljs requires in ns forms 

### DIFF
--- a/core/src/cljstyle/format/ns.clj
+++ b/core/src/cljstyle/format/ns.clj
@@ -205,7 +205,7 @@
   (when (seq elements)
     (->> elements
          (mapcat expand-require-group)
-         (sort-by libspec-sort-key)
+         (sort-by (comp name libspec-sort-key))
          (mapcat expand-comments)
          (render-block base-indent kw))))
 

--- a/core/test/cljstyle/format/ns_test.clj
+++ b/core/test/cljstyle/format/ns_test.clj
@@ -278,3 +278,13 @@
   ;; - inside import?
   ;; - complex combos
   ,,,)
+
+
+(deftest shadow-cljs-requires
+  (is (= "(ns foo
+  (:require
+    [bar.core :as bar]
+    [\"caz\" :as caz]))"
+         (reformat-ns
+           "(ns foo (:require [\"caz\" :as caz] [bar.core :as bar]))"))
+      "sorts a require with a mixture of strings and symbol namespaces"))


### PR DESCRIPTION
shadow-cljs diverges from standard Clojure by allowing namespaces in an `ns` form to be strings instead of symbols. Normalize the libspec-sort-key to a string before sorting. Before this patch, the added test would fail with an exception:

> java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.Symbol
