### PR TITLE
Fix indent after comment

### DIFF
--- a/core/src/cljstyle/format/indent.clj
+++ b/core/src/cljstyle/format/indent.clj
@@ -50,7 +50,8 @@
 (defn- should-indent?
   "True if indentation should exist after the current location."
   [zloc]
-  (and (line-break? zloc) (not (line-break-next? zloc))))
+  (or (and (line-break? zloc) (not (line-break-next? zloc)))
+      (and (zl/comment? zloc) (not (comment-next? zloc)))))
 
 
 (defn- should-unindent?

--- a/core/test/cljstyle/format/indent_test.clj
+++ b/core/test/cljstyle/format/indent_test.clj
@@ -148,3 +148,10 @@
   (testing "reader macros"
     (is (= "#inst\n\"2018-01-01T00:00:00.000-00:00\""
            (reindent-string "#inst\n\"2018-01-01T00:00:00.000-00:00\"")))))
+
+
+(deftest comment-indentation
+  (is (= "(defn f\n  [a;a\n   b ; b\n   ]\n  #{a\n    b;\n    })"
+         (reindent-string "(defn f [a;a\n  b ; b\n]\n #{a\nb;\n})")))
+  (is (= "(foo [1\n      2;\n      ]\n     [3\n      4;\n      ])"
+         (reindent-string "(foo [1\n2;\n]\n[3\n4;\n])"))))


### PR DESCRIPTION
Fix indent after comment with last element in list.
This bug occurs when including multiple lists.

Bug Example:
```clj
(foo [1
      2; comment A
]
     [3
      4; comment B
      ])
```

This PR:
```clj
(foo [1
      2; comment A
      ]
     [3
      4; comment B
      ])
```