### PR TITLE
Add deps.edn for usage as a library

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["resources" "src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/tools.reader {:mvn/version "1.3.2"}
+        com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
+        rewrite-clj {:mvn/version "0.6.1"}}}


### PR DESCRIPTION
Adding a `deps.edn` file allows me to use this code as a library to print formatted code:

```clojure
(require 'cljstyle.format.core)
(defn reformat-code [code]
  (str (cljstyle.format.core/reformat-string (pr-str code))))
```

Thank you!