### PR TITLE
Adjustable block indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .clj-kondo/.cache
 /cljstyle
 /dist
+*.iml
+/.idea

--- a/doc/indentation.md
+++ b/doc/indentation.md
@@ -96,6 +96,28 @@ But indents at a constant two spaces otherwise:
   bang)
 ```
 
+Indents can be customized to use the nth argument as the basis for indenting.
+
+For example,
+
+```clojure
+{foo [[:block 1 2]]}
+```
+
+Will indent from
+
+```clojure
+(foo bar baz
+bang)
+```
+
+to 
+
+```clojure
+(foo bar baz
+         bang)
+```
+
 ### Stair rules
 
 A `:stair` rule is similar to `:block`, except that it tries to indent

--- a/resources/cljstyle/indents.clj
+++ b/resources/cljstyle/indents.clj
@@ -1,7 +1,6 @@
 {alt!            [[:block 0]]
  alt!!           [[:block 0]]
  are             [[:block 2]]
- assoc           [[:block 1 2]]
  as->            [[:block 1]]
  binding         [[:block 1]]
  bound-fn        [[:inner 0]]

--- a/resources/cljstyle/indents.clj
+++ b/resources/cljstyle/indents.clj
@@ -1,6 +1,7 @@
 {alt!            [[:block 0]]
  alt!!           [[:block 0]]
  are             [[:block 2]]
+ assoc           [[:block 1 2]]
  as->            [[:block 1]]
  binding         [[:block 1]]
  bound-fn        [[:inner 0]]

--- a/src/cljstyle/format/indent.clj
+++ b/src/cljstyle/format/indent.clj
@@ -123,7 +123,9 @@
 (defn- repeated-move
   "Repeatedly move a direction"
   [zloc move n]
-  (nth (iterate move zloc) n))
+  (if (> n 0)
+    (recur (move zloc) move (dec n))
+    zloc))
 
 
 (defn- list-indent

--- a/test/cljstyle/config_test.clj
+++ b/test/cljstyle/config_test.clj
@@ -14,7 +14,8 @@
     (is (invalid? ::config/indenter [:abc 2]))
     (is (valid? ::config/indenter [:inner 0]))
     (is (valid? ::config/indenter [:inner 0 1]))
-    (is (valid? ::config/indenter [:block 2])))
+    (is (valid? ::config/indenter [:block 2]))
+    (is (valid? ::config/indenter [:block 1 2])))
   (testing "indent-rule"
     (is (invalid? ::config/indent-rule "foo"))
     (is (invalid? ::config/indent-rule #{[:inner 0]}))

--- a/test/cljstyle/format/indent_test.clj
+++ b/test/cljstyle/format/indent_test.clj
@@ -45,10 +45,13 @@
   (is (= "(deftype Foo\n  [x]\n\n  Bar)"
          (reindent-string "(deftype Foo\n[x]\nBar)")))
 
-  (is (= "(assoc {} :foo bar\n          :foo2 bar2)"
-         (reindent-string "(assoc {} :foo bar\n:foo2 bar2)")))
-  (is (= "(assoc {}\n  :foo bar\n  :foo2 bar2)"
-         (reindent-string "(assoc {}\n:foo bar\n:foo2 bar2)"))))
+  (let [assoc-config (assoc config/default-indents 'assoc [[:block 1 2]])]
+    (is (= "(assoc {} :foo bar\n          :foo2 bar2)"
+           (reindent-string "(assoc {} :foo bar\n:foo2 bar2)"
+                            assoc-config)))
+    (is (= "(assoc {}\n  :foo bar\n  :foo2 bar2)"
+           (reindent-string "(assoc {}\n:foo bar\n:foo2 bar2)"
+                            assoc-config)))))
 
 
 (deftest stair-indentation

--- a/test/cljstyle/format/indent_test.clj
+++ b/test/cljstyle/format/indent_test.clj
@@ -43,7 +43,12 @@
   (is (= "(do (foo)\n    (bar))"
          (reindent-string "(do (foo)\n(bar))")))
   (is (= "(deftype Foo\n  [x]\n\n  Bar)"
-         (reindent-string "(deftype Foo\n[x]\nBar)"))))
+         (reindent-string "(deftype Foo\n[x]\nBar)")))
+
+  (is (= "(assoc {} :foo bar\n          :foo2 bar2)"
+         (reindent-string "(assoc {} :foo bar\n:foo2 bar2)")))
+  (is (= "(assoc {}\n  :foo bar\n  :foo2 bar2)"
+         (reindent-string "(assoc {}\n:foo bar\n:foo2 bar2)"))))
 
 
 (deftest stair-indentation


### PR DESCRIPTION
Supports custom block config as discussed in cljfmt issue https://github.com/weavejester/cljfmt/issues/101

Basically makes for some nicer assoc forms, if people want to configure it as such.