### PR TITLE
Update vim instructions

### DIFF
--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -11,29 +11,18 @@ naming it `_cljstyle`. This will complete the commands and tool options.
 
 ### Vim
 
-For a simple vim integration copy the following into your `.vimrc` or neovim
-`.config/nvim/init.vim`:
+For a simple vim integration set either `'equalprg'` (or `'formatprg'`) for 
+the clojure filetype:
 
 ```vim
-function! cljstyle()
-    let cwd = getcwd()
-    let winsave = winsaveview()
-    execute "cd" . expand('%:p:h')
+" ~/.vim/after/ftplugin/clojure.vim
 
-    :%!cljstyle pipe
-
-    execute "cd" . cwd
-    call winrestview(winsave)
-endfunction
+setlocal equalprg=cljstyle\ pipe
+" or setlocal formatprg=cljstyle\ pipe
 ```
 
-Calling `cljstyle()` will run `cljstyle pipe` on the current buffer.
-
-You can optionally add this line to auto cljstyle on save:
-
-```vim
-autocmd BufWritePre *.clj* call cljstyle()
-```
+Use the `=` operator (or the `gq` operator) to filter the selected lines
+through `cljstyle pipe`.
 
 
 ### tools.deps


### PR DESCRIPTION
Vimmers usually prefer to separate filetype settings, and also to use equalprg and formatprg for indent/formatting tools.

This also has the advantage of being simpler to setup, and uses the motions already learned for formatting (`=` and `gq`).