### PR TITLE
Make build work with jdk11 and graal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ cljstyle: $(uberjar_path)
 	    --no-fallback \
 	    --allow-incomplete-classpath \
 	    --report-unsupported-elements-at-runtime \
-	    --initialize-at-build-time \
+	    --initialize-at-build-time=clojure \
 	    -J-Xms3G -J-Xmx3G \
 	    --no-server \
 	    -jar $<

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["resources" "src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.10.2-alpha1"}
         org.clojure/tools.cli {:mvn/version "0.4.2"}
         org.clojure/tools.reader {:mvn/version "1.3.2"}
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   [[lein-cloverage "1.1.0"]]
 
   :dependencies
-  [[org.clojure/clojure "1.9.0"]
+  [[org.clojure/clojure "1.10.2-alpha1"]
    [org.clojure/tools.cli "0.4.2"]
    [org.clojure/tools.reader "1.3.2"]
    [com.googlecode.java-diff-utils/diffutils "1.3.0"]
@@ -35,4 +35,6 @@
    :uberjar
    {:target-path "target/uberjar"
     :uberjar-name "cljstyle.jar"
-    :aot :all}})
+    :aot :all
+    :jvm-opts ["-Dclojure.compiler.direct-linking=true"
+               "-Dclojure.spec.skip-macros=true"]}})


### PR DESCRIPTION
Bump clojure to 1.10.2-alpha1 and change graal flag from `--initialize-at-build-time` to `--initialize-at-build-time=clojure`

Presumably backwards compatible for jdk8 but need help testing