### PR TITLE
Add --exclude-dir CLI arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for setting `--exclude-dir` CLI options that allow you to
   specify directories to ignore at runtime.
+  [#44](https://github.com/greglook/cljstyle/pull/44)
 
 
 ## [0.12.1] - 2020-02-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-
-- Added support for setting `--exclude-dir` CLI options that allow you to
-  specify directories to ignore at runtime.
+- Added support for setting `--exclude` CLI options that allow you to specify
+  directories/files to ignore at runtime.
   [#44](https://github.com/greglook/cljstyle/pull/44)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+
+- Added support for setting `--exclude-dir` CLI options that allow you to
+  specify directories to ignore at runtime.
 
 
 ## [0.12.1] - 2020-02-22

--- a/doc/completion.zsh
+++ b/doc/completion.zsh
@@ -10,6 +10,7 @@ _cljstyle() {
         "--no-color[disable color output]" \
         "--verbose[verbose logging output]" \
         "--help[show usage information]" \
+        "--exclude=[exclude globs]:Java file globs to exclude:_files" \
         "1:command:((find\\:'Find files which would be processed'
                      check\\:'Check source files and print a diff for errors'
                      fix\\:'Edit source files to fix formatting errors'

--- a/src/cljstyle/config.clj
+++ b/src/cljstyle/config.clj
@@ -11,10 +11,7 @@
     [clojure.spec.alpha :as s])
   (:import
     java.io.File
-    (java.nio.file
-      FileSystem
-      FileSystems
-      PathMatcher)))
+    java.nio.file.FileSystems))
 
 
 ;; ## Specs

--- a/src/cljstyle/config.clj
+++ b/src/cljstyle/config.clj
@@ -6,10 +6,15 @@
   subtree rooted in the directory the file resides in, with deeper files
   merging and overriding their parents."
   (:require
+    [cljstyle.task.print :as p]
     [clojure.java.io :as io]
     [clojure.spec.alpha :as s])
   (:import
-    java.io.File))
+    java.io.File
+    (java.nio.file
+      FileSystem
+      FileSystems
+      PathMatcher)))
 
 
 ;; ## Specs
@@ -188,18 +193,25 @@
 (defn ignored?
   "True if the file should be ignored."
   [config ^File file]
-  (some
-    (fn test-rule
-      [rule]
-      (cond
-        (string? rule)
-        (= rule (.getName file))
+  (or
+    (some
+      (fn test-rule
+        [rule]
+        (cond
+          (string? rule)
+          (= rule (.getName file))
 
-        (pattern? rule)
-        (boolean (re-seq rule (.getCanonicalPath file)))
+          (pattern? rule)
+          (boolean (re-seq rule (.getCanonicalPath file)))
 
-        :else false))
-    (:file-ignore config)))
+          :else false))
+      (:file-ignore config))
+    (some
+      (fn test-glob
+        [glob]
+        (let [path-matcher (.getPathMatcher (FileSystems/getDefault) (str "glob:" glob))]
+          (.matches path-matcher (.toPath file))))
+      (p/option :exclude-dirs))))
 
 
 

--- a/src/cljstyle/config.clj
+++ b/src/cljstyle/config.clj
@@ -6,7 +6,6 @@
   subtree rooted in the directory the file resides in, with deeper files
   merging and overriding their parents."
   (:require
-    [cljstyle.task.print :as p]
     [clojure.java.io :as io]
     [clojure.spec.alpha :as s])
   (:import
@@ -189,7 +188,7 @@
 
 (defn ignored?
   "True if the file should be ignored."
-  [config ^File file]
+  [config exclude-globs ^File file]
   (or
     (some
       (fn test-rule
@@ -208,7 +207,7 @@
         [glob]
         (let [path-matcher (.getPathMatcher (FileSystems/getDefault) (str "glob:" glob))]
           (.matches path-matcher (.toPath file))))
-      (p/option :exclude-dirs))))
+      exclude-globs)))
 
 
 

--- a/src/cljstyle/main.clj
+++ b/src/cljstyle/main.clj
@@ -14,7 +14,15 @@
    [nil  "--stats FILE" "Write formatting stats to the named file. The extension controls the format and may be either 'edn' or 'tsv'."]
    [nil  "--no-color" "Don't output ANSI color codes."]
    ["-v" "--verbose" "Print detailed debugging output."]
-   ["-h" "--help" "Show help and usage information."]])
+   ["-h" "--help" "Show help and usage information."]
+   {:id :exclude-dirs
+    :long-opt "--exclude-dir"
+    :required "GLOB"
+    :desc "A directory glob to exclude from styling. May be set multiple times."
+    :default #{}
+    :assoc-fn (fn assoc-exclude-dirs
+                [options current-id parsed]
+                (update options current-id conj parsed))}])
 
 
 (defn- print-general-usage

--- a/src/cljstyle/main.clj
+++ b/src/cljstyle/main.clj
@@ -15,12 +15,13 @@
    [nil  "--no-color" "Don't output ANSI color codes."]
    ["-v" "--verbose" "Print detailed debugging output."]
    ["-h" "--help" "Show help and usage information."]
-   {:id :exclude-dirs
-    :long-opt "--exclude-dir"
+   {:id :excludes
+    :long-opt "--exclude"
     :required "GLOB"
-    :desc "A directory glob to exclude from styling. May be set multiple times."
+    :desc "A Java file glob to exclude from styling. May be set multiple times."
     :default #{}
-    :assoc-fn (fn assoc-exclude-dirs
+    :default-desc ""
+    :assoc-fn (fn assoc-excludes
                 [options current-id parsed]
                 (update options current-id conj parsed))}])
 

--- a/src/cljstyle/task/process.clj
+++ b/src/cljstyle/task/process.clj
@@ -95,7 +95,7 @@
         (bound-fn compute!
           []
           (cond
-            (config/ignored? config file)
+            (config/ignored? config (p/option :excludes) file)
             (report!
               {:type :ignored
                :debug (str "Ignoring file " path)})

--- a/test/cljstyle/config_test.clj
+++ b/test/cljstyle/config_test.clj
@@ -131,10 +131,11 @@
           (is (config/source-file? config foo-clj))))
       (testing "ignored?"
         (let [config {:file-ignore #{"foo" #"test-config/predicates/bar" :bad}}]
-          (is (not (config/ignored? config test-dir)))
-          (is (not (config/ignored? config foo-clj)))
-          (is (config/ignored? config (io/file test-dir "foo")))
-          (is (config/ignored? config (io/file test-dir "bar")))))
+          (is (not (config/ignored? config #{} test-dir)))
+          (is (not (config/ignored? config #{} foo-clj)))
+          (is (config/ignored? config #{} (io/file test-dir "foo")))
+          (is (config/ignored? config #{} (io/file test-dir "bar")))
+          (is (config/ignored? {} #{"**/bar"} (io/file test-dir "bar")))))
       (finally
         (when (.exists foo-clj)
           (.delete foo-clj))))))


### PR DESCRIPTION
This allows you to specify one or many Java glob(s) of files to ignore at runtime.