### PR TITLE
Handle ns attr-map [#50]

### DIFF
--- a/test/cljstyle/format/ns_test.clj
+++ b/test/cljstyle/format/ns_test.clj
@@ -41,6 +41,30 @@
                       {:list-indent-size 1}))))
 
 
+(deftest ns-metadata-as-attr-map
+  (is (= "(ns foo.bar.meta
+  {:no-doc true
+   :internal true})"
+         (reformat-ns "(ns foo.bar.meta
+
+ {:no-doc true
+     :internal true}   )")))
+  (is (= "(ns foo.bar.meta
+  {:no-doc true
+   :internal true})"
+         (reformat-ns "(ns foo.bar.meta
+ {:no-doc true
+,     :internal true}   )")))
+  (is (= "(ns foo.bar.meta
+  {:no-doc true
+   ;; a comment
+   :internal true})"
+         (reformat-ns "(ns foo.bar.meta
+ {    :no-doc true
+     ;; a comment
+ :internal true}   )"))))
+
+
 (deftest ns-requires
   (is (= "(ns foo.bar.baz\n  \"ns-level docstring\"\n  (:require\n    [foo.bar.qux :refer :all]))"
          (reformat-ns "(ns foo.bar.baz\n \"ns-level docstring\"\n (:use foo.bar.qux)\n)")))


### PR DESCRIPTION
This is my attempt to resolve #50. It's not yet correct, since the indentation for the map is wrong (the failing test is testing for what I believe should be the correct format), but I wanted to put up what I had so far for discussion.

This currently formats:

```
(ns foo
      {:foo :bar 
   :baz true})
```

As: 

```
(ns foo
  {:foo :bar 
 :baz true})
```

Instead of:

```
(ns foo
  {:foo :bar 
   :baz true})
```

What do I need to change to have this format correctly? 