### PR TITLE
Create pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: cljstyle
   name: cljstyle
   description: cljstyle is a tool for formatting Clojure code
-  entry: cljstyle fix
+  entry: cljstyle fix --report
   language: docker
   files: \.(clj[sc]?|edn)$
   types: [file]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: cljstyle
+  name: cljstyle
+  description: cljstyle is a tool for formatting Clojure code
+  entry: cljstyle fix
+  language: docker
+  files: \.(clj[sc]?|edn)$
+  types: [file]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+RUN apt-get update \
+    && apt-get -y install curl \
+    && curl -LO https://github.com/greglook/cljstyle/releases/download/0.13.0/cljstyle_0.13.0_linux.tar.gz \
+    && tar -zxvf cljstyle_0.13.0_linux.tar.gz \
+    && mv cljstyle /usr/local/bin
+ENTRYPOINT cljstyle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM ubuntu:20.04
-RUN apt-get update \
-    && apt-get -y install curl \
-    && curl -LO https://github.com/greglook/cljstyle/releases/download/0.13.0/cljstyle_0.13.0_linux.tar.gz \
-    && tar -zxvf cljstyle_0.13.0_linux.tar.gz \
-    && mv cljstyle /usr/local/bin
+FROM frolvlad/alpine-glibc:alpine-3.12
+COPY project.clj .
+RUN apk add --no-cache wget tar \
+    && version=$(cat project.clj | grep defproject | cut -d' ' -f3 | cut -d'"' -f2) \
+    && wget https://github.com/greglook/cljstyle/releases/download/$version/cljstyle_${version}_linux.tar.gz \
+    && tar -zxvf cljstyle_${version}_linux.tar.gz
+
+FROM frolvlad/alpine-glibc:alpine-3.12
+COPY --from=0 cljstyle /usr/local/bin
 ENTRYPOINT cljstyle


### PR DESCRIPTION
pre-commit supports [Docker-based hooks](https://pre-commit.com/#docker). This PR creates a Dockerfile that just grabs the current release of cljstyle and installs it in a Docker image to be run by the hook. This is much simpler and more performant than building cljstyle from scratch.

An alternative to this configuration would be to have the Dockerfile actually build cljstyle, push the resulting image, and then use the [docker_image](https://pre-commit.com/#docker_image) pre-commit hook type.

Resolves #57.