### PR TITLE
Create pre-commit hook configuration - docker_image alternative

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: cljstyle
   name: cljstyle
   description: cljstyle is a tool for formatting Clojure code
-  entry: cljstyle fix
-  language: docker
+  entry: --entrypoint cljstyle robhanlon22/cljstyle:0.13.0 fix
+  language: docker_image
   files: \.(clj[sc]?|edn)$
   types: [file]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: cljstyle
+  name: cljstyle
+  description: cljstyle is a tool for formatting Clojure code
+  entry: cljstyle fix
+  language: docker
+  files: \.(clj[sc]?|edn)$
+  types: [file]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+RUN apt-get update \
+    && apt-get -y install curl \
+    && curl -LO https://github.com/greglook/cljstyle/releases/download/0.13.0/cljstyle_0.13.0_linux.tar.gz \
+    && tar -zxvf cljstyle_0.13.0_linux.tar.gz \
+    && mv cljstyle /usr/local/bin
+ENTRYPOINT cljstyle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:20.04
+COPY . /src
 RUN apt-get update \
-    && apt-get -y install curl \
-    && curl -LO https://github.com/greglook/cljstyle/releases/download/0.13.0/cljstyle_0.13.0_linux.tar.gz \
-    && tar -zxvf cljstyle_0.13.0_linux.tar.gz \
-    && mv cljstyle /usr/local/bin
+    && apt-get -y install build-essential libz-dev curl leiningen \
+    && cd /src \
+    && make package \
+    && chmod +x cljstyle
+
+FROM ubuntu:20.04
+COPY --from=0 /src/cljstyle /usr/local/bin/cljstyle
 ENTRYPOINT cljstyle


### PR DESCRIPTION
This is the alternative approach as discussed in #58. This uses a pre-commit to run cljstyle via a pre-built Docker image.

Resolves #57.