### PR TITLE
Fix formatting when there's an inline comment on the final line

### DIFF
--- a/src/cljstyle/format/whitespace.clj
+++ b/src/cljstyle/format/whitespace.clj
@@ -3,7 +3,8 @@
   (:require
     [cljstyle.format.zloc :as zl]
     [rewrite-clj.node :as n]
-    [rewrite-clj.zip :as z]))
+    [rewrite-clj.zip :as z]
+    [rewrite-clj.zip.whitespace :as ws]))
 
 
 ;; ## Rule: Surrounding Whitespace
@@ -77,10 +78,15 @@
 
 ;; ## Rule: Trailing Whitespace
 
+(defn- rightmost?
+  [zloc]
+  (nil? (ws/skip z/right* ws/whitespace? (z/right* zloc))))
+
+
 (defn- final?
   "True if this location is the last top-level node."
   [zloc]
-  (and (z/rightmost? zloc) (zl/root? (z/up zloc))))
+  (and (rightmost? zloc) (zl/root? (z/up zloc))))
 
 
 (defn- trailing-whitespace?

--- a/test/cljstyle/format/whitespace_test.clj
+++ b/test/cljstyle/format/whitespace_test.clj
@@ -79,6 +79,10 @@
   (testing "with trailing whitespace"
     (is (rule-reformatted?
           ws/remove-trailing {}
+          "(foo bar) ; hello"
+          "(foo bar) ; hello"))
+    (is (rule-reformatted?
+          ws/remove-trailing {}
           "(foo bar) "
           "(foo bar)"))
     (is (rule-reformatted?


### PR DESCRIPTION
This includes a test case to illustrate the issue.

The TLDR is that rewrite-clj treats comments as whitespace, so if there
is a trailing comment on the final line of a form, cljstyle would tell
you to remove the space between the form and the comment because it
considered the whole rest of the line to be whitespace.