### PR TITLE
Make ignore behavior match documentation

### DIFF
--- a/test/cljstyle/config_test.clj
+++ b/test/cljstyle/config_test.clj
@@ -142,6 +142,9 @@
           (is (config/ignored? config #{} (io/file test-dir "foo")))
           (is (config/ignored? config #{} (io/file test-dir "bar")))
           (is (config/ignored? {} #{"bar"} (io/file test-dir "bar")))))
+      (testing "ignored? + relative paths"
+        (let [config {:files {:ignore #{#"^target/test-config/predicates/bar"}}}]
+          (is (config/ignored? config #{} (io/file test-dir "bar")))))
       (finally
         (when (.exists foo-clj)
           (.delete foo-clj))))))


### PR DESCRIPTION
The [configuration doc](https://github.com/greglook/cljstyle/blob/bb79e3ad0a2db0541d137a81aedd40455de5c143/doc/configuration.md#file-settings) says this under the `:ignore` bullet point:

> ...patterns are matched against the entire (relative) file path...

However, this is not the case in the implementation, as `cljstyle.config/ignored?` uses the canonical path, rather than a relatived version of it.

To match the docs, this change relativizes the canonical path to the file against the JVM working dir. Hopefully this is the intended behavior :)