### PR TITLE
Use :block rule as baseline indentation for :stair rule

### DIFF
--- a/src/cljstyle/format/indent.clj
+++ b/src/cljstyle/format/indent.clj
@@ -287,13 +287,15 @@
 (defn- stair-indent
   "Calculate how many spaces the node at this location should be indented as a
   conditional block. Returns nil if the rule does not apply."
-  [zloc rule-key idx]
+  [zloc rule-key idx list-indent-size]
   (when (indent-matches? rule-key (zl/form-symbol-full zloc))
     (let [zloc-idx (index-of zloc)
           leading-forms (if (some-> zloc (nth-form idx) first-form-in-line?)
                           0
                           idx)
-          indent (inner-indent zloc rule-key 0 nil)]
+          indent (if (zero? idx)
+                   (block-indent zloc rule-key idx list-indent-size (inc idx))
+                   (inner-indent zloc rule-key 0 nil))]
       (if (even? (- zloc-idx leading-forms))
         (+ indent indent-size)
         indent))))
@@ -322,7 +324,7 @@
     (let [[_ idx] rule]
       (fn stair-indenter
         [zloc]
-        (stair-indent zloc rule-key idx)))))
+        (stair-indent zloc rule-key idx list-indent-size)))))
 
 
 (defn- unindent-line

--- a/test/cljstyle/format/indent_test.clj
+++ b/test/cljstyle/format/indent_test.clj
@@ -61,6 +61,12 @@
           "(assoc {}\n  :foo bar\n  :foo2 bar2)"))))
 
 
+(defn space
+  "A string with n spaces"
+  [n]
+  (apply str (repeat n " ")))
+
+
 (deftest stair-indentation
   (let [indents {'cond [[:stair 0]]
                  'condp [[:stair 2]]
@@ -70,6 +76,14 @@
           indent/reindent-lines {:indents indents}
           "(cond\na? a\n   b? b)"
           "(cond\n  a? a\n  b? b)"))
+    (is (rule-reformatted?
+          indent/reindent-lines {:indents indents}
+          "(cond a? a\n   b? b)"
+          (str "(cond a? a\n" (space 6) "b? b)")))
+    (is (rule-reformatted?
+          indent/reindent-lines {:indents indents}
+          "(cond a?\n a\n   b?\n b)"
+          (str "(cond a?\n" (space 8) "a\n" (space 6) "b?\n" (space 8) "b)")))
     (is (rule-reformatted?
           indent/reindent-lines {:indents indents}
           "(cond\na?\n a\nb?\n  b)"


### PR DESCRIPTION
Fix #97

Sorry about opening this before the underlying issue has been responded to, I had some extra time and thought I'd try my proposed fix.

A better solution might be to introduce a new rule instead, or add extra parameters to the rule as this would change some behaviour when leading forms are missing (see my comment in the tests).