### PR TITLE
Make Dockerfile work on more platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-11-lein-2.9.1
+FROM --platform=linux/amd64 clojure:openjdk-11-lein-2.9.1
 
 # Install essential tooling
 RUN apt update


### PR DESCRIPTION
We're installing the amd64 version of Graal, but if this is run on an M1 Mac for example, it'll install an ARM version, which will fail to compile.