### PR TITLE
Vertical alignment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,33 @@
 /target
 /dist
 pom.xml
+
+#########
+# macOS #
+#########
+
+# General
+.DS_Store
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[]
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/README.md
+++ b/README.md
@@ -184,7 +184,17 @@ The `cljstyle` tool comes with a sensible set of default configuration built-in
 and may additionally be configured by using a hierarchy of `.cljstyle` files in
 the source tree. The [configuration settings](doc/configuration.md) include
 toggles for format rules, width constraints, and the
-[indentation rules](doc/indentation.md).
+[indentation rules](doc/indentation.md). You can also opt into vertical
+alignment with the `:rules {:align ...}` configuration, for example:
+
+```clojure
+{:rules
+ {:align
+  {:enabled? true}}}
+```
+
+See [`:align` in `doc/configuration.md`](doc/configuration.md) for all defaults
+and options.
 
 
 ## Ignoring Forms

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -103,6 +103,71 @@ leading spaces on each line.
   A map of indentation patterns to vectors of rules to apply to the matching
   forms. See the [indentation doc](indentation.md) for details.
 
+### `:align`
+
+This opt-in rule applies vertical alignment to associative forms. By default it
+aligns maps, let-like binding vectors, and cond-like forms.
+
+Default configuration:
+
+```clojure
+{:rules
+ {:align
+  {:enabled? false
+   :targets #{:maps :bindings :clauses :reader-conditionals}
+   :extra-binding-forms []
+   :extra-clause-forms {}
+   :exclude-forms #{}
+   :indent-comments? true}}}
+```
+
+* `:targets`
+
+  Set of structural targets to align. Supported values are `:maps`,
+  `:bindings`, `:clauses`, and `:reader-conditionals`.
+
+* `:extra-binding-forms`
+
+  Vector of additional form names whose first binding vector should be
+  aligned.
+
+* `:extra-clause-forms`
+
+  Map of additional clause-style form names to the number of leading arguments
+  skipped before pairwise alignment.
+
+* `:exclude-forms`
+
+  Set of form names removed from alignment handling, including built-in
+  behavior and custom additions.
+
+* `:indent-comments?`
+
+  When true, standalone comments can be indented to match the next
+  substantive line in the same aligned group.
+
+Built-in support includes common let-style and cond-style forms. Reader
+conditionals are aligned when `:reader-conditionals` is present in `:targets`.
+Blank lines split alignment groups.
+
+Example:
+
+```clojure
+;; input
+(let [foo "bar"
+      bazqux "squid"])
+
+{:foo "bar"
+ :bazqux "squid"}
+
+;; output
+(let [foo    "bar"
+      bazqux "squid"])
+
+{:foo    "bar"
+ :bazqux "squid"}
+```
+
 ### `:whitespace`
 
 This rule corrects whitespace between and around forms.

--- a/src/cljstyle/config.clj
+++ b/src/cljstyle/config.clj
@@ -251,10 +251,52 @@
                    :cljstyle.config.rules.namespaces/import-break-width]))
 
 
+;; #### Rule: Align
+
+;; Structural alignment targets that can be enabled or disabled.
+(s/def :cljstyle.config.rules.align/target
+  #{:maps :bindings :clauses :reader-conditionals})
+
+
+;; Set of structural alignment targets to apply.
+(s/def :cljstyle.config.rules.align/targets
+  (s/coll-of :cljstyle.config.rules.align/target :kind set?))
+
+
+;; Additional form names whose first binding vector should be aligned.
+(s/def :cljstyle.config.rules.align/extra-binding-forms
+  (s/coll-of string? :kind vector?))
+
+
+;; Additional clause-style form names with leading argument skip counts.
+(s/def :cljstyle.config.rules.align/extra-clause-forms
+  (s/map-of string? nat-int?))
+
+
+;; Form names to exclude from built-in and custom alignment handling.
+(s/def :cljstyle.config.rules.align/exclude-forms
+  (s/coll-of string? :kind set?))
+
+
+;; Whether standalone comments should follow the next substantive line's indent.
+(s/def :cljstyle.config.rules.align/indent-comments?
+  boolean?)
+
+
+(s/def :cljstyle.config.rules/align
+  (s/keys :opt-un [:cljstyle.config.rules.global/enabled?
+                   :cljstyle.config.rules.align/targets
+                   :cljstyle.config.rules.align/extra-binding-forms
+                   :cljstyle.config.rules.align/extra-clause-forms
+                   :cljstyle.config.rules.align/exclude-forms
+                   :cljstyle.config.rules.align/indent-comments?]))
+
+
 ;; #### Rules Map
 
 (s/def ::rules
   (s/keys :opt-un [:cljstyle.config.rules/indentation
+                   :cljstyle.config.rules/align
                    :cljstyle.config.rules/whitespace
                    :cljstyle.config.rules/blank-lines
                    :cljstyle.config.rules/eof-newline
@@ -287,6 +329,10 @@
 (def default-indents
   "Default indentation rules included with the library."
   (read-file (io/resource "cljstyle/indents.clj")))
+
+
+(def default-align-targets
+  #{:maps :bindings :clauses :reader-conditionals})
 
 
 (def legacy-config
@@ -325,6 +371,14 @@
     {:enabled? true
      :list-indent 2
      :indents default-indents}
+
+    :align
+    {:enabled? false
+     :targets default-align-targets
+     :extra-binding-forms []
+     :extra-clause-forms {}
+     :exclude-forms #{}
+     :indent-comments? true}
 
     :whitespace
     {:enabled? true

--- a/src/cljstyle/format/align.clj
+++ b/src/cljstyle/format/align.clj
@@ -1,0 +1,56 @@
+(ns cljstyle.format.align
+  "Formatting rules for vertical alignment in associative forms.
+
+  This rule aligns map entries, binding vectors, clause-style forms, and
+  reader conditional bodies by scanning adjacent cells within blank-line
+  groups, planning target columns, then applying spacing edits."
+  (:require
+    [cljstyle.format.align.config :as config]
+    [cljstyle.format.align.plan :as plan]
+    [cljstyle.format.align.target :as target]
+    [cljstyle.format.align.walk :as walk]
+    [rewrite-clj.zip :as z]))
+
+
+(defn- alignable-node?
+  "Predicate for nodes supported by alignment."
+  [zloc rule-config]
+  (let [rule-config (config/effective-config rule-config)]
+    (boolean (target/node-alignment-kind zloc rule-config))))
+
+
+(defn- align-node
+  "Apply alignment to one supported node using rule and indent config.
+
+  Clause forms consult indentation rules to derive head argument skip counts."
+  ([zloc rule-config]
+   (align-node zloc rule-config nil))
+  ([zloc rule-config rules-config]
+   (let [rule-config (config/effective-config rule-config)
+         rules-config (or rules-config {})
+         alignment-kind (target/node-alignment-kind zloc rule-config)
+         start (target/resolve-start-node-for-kind
+                 zloc
+                 alignment-kind
+                 rule-config
+                 rules-config)]
+     (if start
+       (let [model (walk/collect-alignment-model
+                     start
+                     {:preserve-prev-on-newline? (= :clause alignment-kind)})
+             column-plan (plan/plan-column-targets model)]
+         (-> (walk/apply-column-targets start column-plan rule-config)
+             z/up))
+       zloc))))
+
+
+(def align-columns
+  "Rule to apply vertical column alignment in associative Clojure forms.
+
+  Aligns map entries, binding vectors, clause-style forms, and reader
+  conditionals. Configure targets with `:targets`, add forms with
+  `:extra-binding-forms` and `:extra-clause-forms`, and opt out forms with
+  `:exclude-forms`. Standalone comments can follow the next substantive line
+  with `:indent-comments?`. Alignment is column-oriented within blank-line
+  groups."
+  [:align nil alignable-node? align-node])

--- a/src/cljstyle/format/align/config.clj
+++ b/src/cljstyle/format/align/config.clj
@@ -1,0 +1,113 @@
+(ns cljstyle.format.align.config
+  "Configuration normalization for the align rule."
+  (:require
+    [clojure.set :as set]))
+
+
+(def ^:private builtin-binding-forms
+  [;; Unqualified built-ins.
+   "binding"
+   "doseq"
+   "for"
+   "if-let"
+   "if-some"
+   "let"
+   "loop"
+   "when-let"
+   "when-some"
+   "with-local-vars"
+   "with-open"
+   "with-redefs"
+
+   ;; Qualified Clojure built-ins.
+   "clojure.core/binding"
+   "clojure.core/doseq"
+   "clojure.core/for"
+   "clojure.core/if-let"
+   "clojure.core/if-some"
+   "clojure.core/let"
+   "clojure.core/loop"
+   "clojure.core/when-let"
+   "clojure.core/when-some"
+   "clojure.core/with-local-vars"
+   "clojure.core/with-open"
+   "clojure.core/with-redefs"
+
+   ;; Qualified ClojureScript built-ins.
+   "cljs.core/binding"
+   "cljs.core/doseq"
+   "cljs.core/for"
+   "cljs.core/if-let"
+   "cljs.core/if-some"
+   "cljs.core/let"
+   "cljs.core/loop"
+   "cljs.core/when-let"
+   "cljs.core/when-some"
+   "cljs.core/with-local-vars"
+   "cljs.core/with-open"
+   "cljs.core/with-redefs"])
+
+
+(def ^:private builtin-clause-forms
+  {;; Unqualified built-ins.
+   "are" 2
+   "case" 1
+   "cond" 0
+   "cond->" 1
+   "cond->>" 1
+   "condp" 2
+
+   ;; Qualified Clojure built-ins.
+   "clojure.core/case" 1
+   "clojure.core/cond" 0
+   "clojure.core/cond->" 1
+   "clojure.core/cond->>" 1
+   "clojure.core/condp" 2
+   "clojure.test/are" 2
+
+   ;; Qualified ClojureScript built-ins.
+   "cljs.core/case" 1
+   "cljs.core/cond" 0
+   "cljs.core/cond->" 1
+   "cljs.core/cond->>" 1
+   "cljs.core/condp" 2
+   "cljs.test/are" 2})
+
+
+(def ^:private default-targets
+  #{:maps :bindings :clauses :reader-conditionals})
+
+
+(def ^:private default-rule-config
+  {:enabled? false
+   :targets default-targets
+   :extra-binding-forms []
+   :extra-clause-forms {}
+   :indent-comments? true
+   :exclude-forms #{}})
+
+
+(defn normalize-config
+  "Merge defaults and precompute lookup structures for alignment checks.
+
+  Built-in and custom form sets are merged, then excluded forms are removed."
+  [rule-config]
+  (let [config (merge default-rule-config rule-config)
+        excluded (set (:exclude-forms config))
+        binding-form-set (set/difference
+                           (set (concat builtin-binding-forms
+                                        (:extra-binding-forms config)))
+                           excluded)
+        clause-form-skips (apply dissoc
+                                 (merge builtin-clause-forms
+                                        (:extra-clause-forms config))
+                                 excluded)]
+    (assoc config
+           :target-set (set (:targets config))
+           :binding-form-set binding-form-set
+           :clause-form-skips clause-form-skips)))
+
+
+(def effective-config
+  "Memoized normalized alignment configuration."
+  (memoize normalize-config))

--- a/src/cljstyle/format/align/continuation.clj
+++ b/src/cljstyle/format/align/continuation.clj
@@ -1,0 +1,201 @@
+(ns cljstyle.format.align.continuation
+  "Multiline continuation padding and standalone comment handling."
+  (:require
+    [cljstyle.format.align.spacing :as spacing]
+    [cljstyle.format.align.syntax :as syntax]
+    [cljstyle.format.zloc :as zl]
+    [clojure.string :as str]
+    [rewrite-clj.zip :as z]))
+
+
+(defn maybe-indent-standalone-comment
+  "Indent a standalone comment to the next substantive node when enabled.
+
+  Comments on the same line as an opening delimiter are left as-is."
+  [comment-loc indent-comments? line-has-content?]
+  (let [parent (z/up comment-loc)]
+    (if (or (not indent-comments?)
+            line-has-content?
+            (= (first (z/position comment-loc))
+               (first (z/position parent))))
+      comment-loc
+      (let [next-loc (syntax/next-form-node comment-loc)
+            target-column (when next-loc (spacing/start-column next-loc))]
+        (if (pos-int? target-column)
+          (spacing/adjust-left-spacing
+            comment-loc
+            (- target-column (spacing/start-column comment-loc)))
+          comment-loc)))))
+
+
+(defn- continuation-comment-break?
+  "True when a continuation node is a comment that already contains a line break."
+  [loc]
+  (and (zl/comment? loc)
+       (str/includes? (zl/zstr loc) "\n")))
+
+
+(defn- next-line-start-after-break
+  "Return the first node on the next continuation line after a line-break node.
+
+  If the next line begins with whitespace followed by a standalone comment,
+  return the comment node so comment lines are padded directly."
+  [line-break-loc]
+  (let [next-loc (z/next* line-break-loc)
+        line-start (cond
+                     (or (nil? next-loc) (z/end? next-loc))
+                     nil
+
+                     (zl/space? next-loc)
+                     (let [content-loc (z/skip z/right* zl/space? next-loc)]
+                       (if (or (nil? content-loc) (z/end? content-loc))
+                         next-loc
+                         (if (zl/comment? content-loc)
+                           content-loc
+                           content-loc)))
+
+                     :else
+                     next-loc)]
+    (when-not (or (nil? line-start) (z/end? line-start))
+      line-start)))
+
+
+(defn- next-continuation-line-node
+  "Find the next continuation line node while scanning within a multiline value."
+  [current-loc]
+  (if (continuation-comment-break? current-loc)
+    (next-line-start-after-break current-loc)
+    (let [current-line (first (z/position current-loc))]
+      (loop [loc (z/next* current-loc)]
+        (cond
+          (or (nil? loc) (z/end? loc))
+          nil
+
+          (syntax/newline-node? loc)
+          (next-line-start-after-break loc)
+
+          (continuation-comment-break? loc)
+          (if (> (first (z/position loc)) current-line)
+            loc
+            (next-line-start-after-break loc))
+
+          :else
+          (recur (z/next* loc)))))))
+
+
+(defn- first-continuation-line-content
+  "Return the first substantive node on a continuation line.
+
+  Leading spaces and commas are skipped; blank lines return nil."
+  [line-node]
+  (let [content-loc (z/skip
+                      z/right*
+                      #(or (zl/space? %)
+                           (syntax/comma-node? %))
+                      line-node)]
+    (when (and content-loc
+               (not (syntax/newline-node? content-loc)))
+      content-loc)))
+
+
+(defn- continuation-anchor-key
+  "Return a stable anchor key describing a continuation content node's parent."
+  [content-loc]
+  (when-let [parent (z/up content-loc)]
+    (let [[line col] (z/position parent)]
+      [line col (z/tag parent)])))
+
+
+(defn- align-content-to-anchor
+  "Shift content horizontally to the stored anchor column when needed."
+  [content-loc anchor]
+  (if (and anchor
+           (not= (spacing/start-column content-loc) anchor))
+    (spacing/adjust-left-spacing
+      content-loc
+      (- anchor (spacing/start-column content-loc)))
+    content-loc))
+
+
+(defn- pad-standalone-continuation-comment
+  "Apply standalone-comment indentation and preserve continuation padding.
+
+  Comment indentation aligns with the next substantive form when enabled; if a
+  next form exists, the continuation padding delta is reapplied."
+  [comment-loc padding indent-comments?]
+  (if (and indent-comments?
+           comment-loc
+           (zl/comment? comment-loc))
+    (let [next-loc (syntax/next-form-node comment-loc)]
+      (cond->
+        (maybe-indent-standalone-comment comment-loc true false)
+        next-loc
+        (spacing/adjust-left-spacing padding)))
+    comment-loc))
+
+
+(defn- pad-continuation-line
+  "Pad one continuation line and update the parent-anchor map.
+
+  Returns `[updated-line-node updated-anchors]`."
+  [line-node padding indent-comments? anchors]
+  (let [line-node (spacing/adjust-left-spacing line-node padding)
+        first-content (first-continuation-line-content line-node)
+        parent-key (when first-content
+                     (continuation-anchor-key first-content))
+        comment-line? (and first-content (zl/comment? first-content))
+        anchors (if (and parent-key
+                         (not comment-line?)
+                         (nil? (get anchors parent-key)))
+                  (assoc anchors parent-key (spacing/start-column first-content))
+                  anchors)
+        anchor (when parent-key (get anchors parent-key))
+        first-content (if (and first-content
+                               (not comment-line?))
+                        (align-content-to-anchor first-content anchor)
+                        first-content)
+        line-node (or first-content line-node)
+        first-content (first-continuation-line-content line-node)
+        line-node (if (and first-content
+                           (zl/comment? first-content))
+                    (pad-standalone-continuation-comment
+                      first-content
+                      padding
+                      indent-comments?)
+                    line-node)]
+    [line-node anchors]))
+
+
+(defn- pad-multiline-continuations
+  "Apply padding to continuation lines inside a multiline node.
+
+  When comment indentation is enabled, standalone comment lines in continuation
+  blocks may follow the next substantive line."
+  [zloc padding indent-comments?]
+  (if-some [line-node (z/down zloc)]
+    (loop [line-node line-node
+           anchors {}]
+      (if-some [next-line-node (next-continuation-line-node line-node)]
+        (let [[line-node anchors] (pad-continuation-line
+                                    next-line-node
+                                    padding
+                                    indent-comments?
+                                    anchors)]
+          (recur line-node anchors))
+        line-node))
+    zloc))
+
+
+(defn pad-node-to-column
+  "Pad a node to a target start column.
+
+  Applies the same delta to multiline continuation lines."
+  [zloc target-column indent-comments?]
+  (let [padding (- target-column (spacing/start-column zloc))
+        pad-subtree (fn [subtree-loc]
+                      (pad-multiline-continuations
+                        subtree-loc
+                        padding
+                        indent-comments?))]
+    (-> (spacing/adjust-left-spacing zloc padding)
+        (z/subedit-> pad-subtree))))

--- a/src/cljstyle/format/align/plan.clj
+++ b/src/cljstyle/format/align/plan.clj
@@ -1,0 +1,78 @@
+(ns cljstyle.format.align.plan
+  "Column target planning for align model graphs."
+  (:require
+    [cljstyle.format.align.spacing :as spacing]))
+
+
+(defn- required-target-column
+  "Compute required target column for a destination column."
+  [source-cell-ids cells row-shift]
+  (when (seq source-cell-ids)
+    (reduce
+      (fn [max-target source-cell-id]
+        (let [{:keys [row-id end]} (get cells source-cell-id)
+              shifted-end (+ end (get row-shift row-id 0))]
+          (max max-target (inc shifted-end))))
+      0
+      source-cell-ids)))
+
+
+(defn- update-row-shifts
+  "Update per-row shifts after applying one destination-column target."
+  [row-shift destination-cell-ids target-column cells]
+  (reduce
+    (fn [row-shift cell-id]
+      (let [{:keys [row-id start has-left-space? left-space-width]}
+            (get cells cell-id)
+            shifted-start (+ start (get row-shift row-id 0))
+            desired-delta (- target-column shifted-start)
+            actual-delta (spacing/spacing-delta
+                           desired-delta
+                           has-left-space?
+                           left-space-width)]
+        (if (zero? actual-delta)
+          row-shift
+          (update row-shift row-id (fnil + 0) actual-delta))))
+    row-shift
+    destination-cell-ids))
+
+
+(defn- plan-group-targets
+  "Plan destination columns for one alignment group."
+  [plan group-id max-column cells cells-by-column constraints]
+  (loop [destination-column 1
+         row-shift {}
+         plan plan]
+    (if (> destination-column max-column)
+      plan
+      (let [source-cell-ids (get constraints [group-id destination-column])
+            target-column (required-target-column source-cell-ids cells row-shift)]
+        (if (nil? target-column)
+          (recur (inc destination-column) row-shift plan)
+          (let [destination-cell-ids (get cells-by-column
+                                          [group-id destination-column]
+                                          [])
+                row-shift (update-row-shifts
+                            row-shift
+                            destination-cell-ids
+                            target-column
+                            cells)]
+            (recur (inc destination-column)
+                   row-shift
+                   (assoc plan [group-id destination-column] target-column))))))))
+
+
+(defn plan-column-targets
+  "Compute final column targets with deterministic lookahead planning."
+  [{:keys [cells cells-by-column constraints max-column-by-group]}]
+  (reduce-kv
+    (fn [plan group-id max-column]
+      (plan-group-targets
+        plan
+        group-id
+        max-column
+        cells
+        cells-by-column
+        constraints))
+    {}
+    max-column-by-group))

--- a/src/cljstyle/format/align/spacing.clj
+++ b/src/cljstyle/format/align/spacing.clj
@@ -1,0 +1,69 @@
+(ns cljstyle.format.align.spacing
+  "Column and spacing math for alignment edits."
+  (:require
+    [cljstyle.format.align.syntax :as syntax]
+    [cljstyle.format.zloc :as zl]
+    [clojure.string :as str]
+    [rewrite-clj.node :as n]
+    [rewrite-clj.zip :as z]))
+
+
+(defn start-column
+  "Return the zero-based starting column of a node."
+  [zloc]
+  (-> zloc z/position second dec))
+
+
+(defn node-end-position
+  "Return the right-edge column of a node, including trailing comma width.
+
+  For multiline nodes, this returns the width of the final physical line."
+  [zloc]
+  (let [[_ col] (z/position zloc)
+        right (z/right* zloc)
+        node-string (zl/zstr zloc)
+        comma-width (if (syntax/comma-node? right)
+                      (count (n/string (z/node right)))
+                      0)
+        line-break (str/last-index-of node-string "\n")
+        line-width (if line-break
+                     (- (count node-string) (inc line-break))
+                     (+ (dec col) (count node-string)))]
+    (+ line-width comma-width)))
+
+
+(defn spacing-delta
+  "Return effective left-spacing delta after separator-space constraints."
+  [desired-delta has-left-space? left-space-width]
+  (if has-left-space?
+    (let [new-width (max 1 (+ left-space-width desired-delta))]
+      (- new-width left-space-width))
+    (if (pos? desired-delta)
+      desired-delta
+      0)))
+
+
+(defn adjust-left-spacing
+  "Adjust immediate left spacing, preserving at least one separating space."
+  [zloc delta]
+  (let [left (z/left* zloc)]
+    (cond
+      (zl/space? left)
+      (let [left-space-width (-> left z/node n/string count)
+            delta (spacing-delta delta true left-space-width)
+            width (+ left-space-width delta)]
+        (z/right* (z/replace* left (n/spaces width))))
+
+      :else
+      (let [delta (spacing-delta delta false 0)]
+        (if (pos? delta)
+          (z/insert-space-left zloc delta)
+          zloc)))))
+
+
+(defn node-left-space-width
+  "Return immediate left-space width for a node, or nil if absent."
+  [zloc]
+  (when-let [left (z/left* zloc)]
+    (when (zl/space? left)
+      (count (n/string (z/node left))))))

--- a/src/cljstyle/format/align/syntax.clj
+++ b/src/cljstyle/format/align/syntax.clj
@@ -1,0 +1,43 @@
+(ns cljstyle.format.align.syntax
+  "Syntax-level zipper predicates and navigation for alignment."
+  (:require
+    [cljstyle.format.zloc :as zl]
+    [rewrite-clj.node :as n]
+    [rewrite-clj.zip :as z]))
+
+
+(defn comma-node?
+  "True if the node at this location is a comma token."
+  [zloc]
+  (and zloc (= :comma (n/tag (z/node zloc)))))
+
+
+(defn newline-node?
+  "True if the node at this location is a newline token."
+  [zloc]
+  (= :newline (n/tag (z/node zloc))))
+
+
+(def ^:private trivial-tags
+  #{:whitespace :comma :newline :comment})
+
+
+(defn- trivial-node?
+  "True if this node is skipped while scanning for alignment cells."
+  [zloc]
+  (contains? trivial-tags (n/tag (z/node zloc))))
+
+
+(defn next-form-node
+  "Return the next substantive sibling node."
+  [zloc]
+  (z/skip z/right* trivial-node? (z/right* zloc)))
+
+
+(defn first-form-node
+  "Return the first substantive child node, unwrapping metadata."
+  [zloc]
+  (-> zloc
+      z/down
+      (#(z/skip z/right* trivial-node? %))
+      zl/unwrap-meta))

--- a/src/cljstyle/format/align/target.clj
+++ b/src/cljstyle/format/align/target.clj
@@ -1,0 +1,163 @@
+(ns cljstyle.format.align.target
+  "Form-kind and start-node resolution for alignment strategies."
+  (:require
+    [cljstyle.format.align.syntax :as syntax]
+    [cljstyle.format.zloc :as zl]
+    [rewrite-clj.node :as n]
+    [rewrite-clj.zip :as z]))
+
+
+(defn- binding-vector?
+  "True if vector is the first binding vector for a configured binding head."
+  [zloc rule-config]
+  (and (z/vector? zloc)
+       (let [parent (z/up zloc)]
+         (when (z/list? parent)
+           (when-let [head-loc (syntax/first-form-node parent)]
+             (and (contains? (:binding-form-set rule-config) (z/string head-loc))
+                  (= zloc (syntax/next-form-node head-loc))))))))
+
+
+(defn- indent-rule->skip-count
+  "Extract clause skip count from one indentation rule option vector."
+  [opts]
+  (let [method (first opts)]
+    (if (and (sequential? method)
+             (number? (second method)))
+      (second method)
+      0)))
+
+
+(defn- compile-clause-skip-matcher
+  "Compile indentation rules into exact, unqualified, and regex skip matchers.
+
+  Rule ordering is stable and preserves first-match precedence."
+  [indents]
+  (reduce
+    (fn compile-rule
+      [{:keys [exact unqualified] :as matcher} [rule-key opts]]
+      (let [skip (indent-rule->skip-count opts)]
+        (cond
+          (and (symbol? rule-key) (namespace rule-key))
+          (assoc matcher :exact (assoc exact rule-key skip))
+
+          (symbol? rule-key)
+          (assoc matcher :unqualified (assoc unqualified rule-key skip))
+
+          (instance? java.util.regex.Pattern rule-key)
+          (update matcher :patterns conj [rule-key skip])
+
+          :else
+          matcher)))
+    {:exact {}
+     :unqualified {}
+     :patterns []}
+    (sort-by
+      (fn [[rule-key _]]
+        (cond
+          (symbol? rule-key)
+          (if (namespace rule-key)
+            (str 0 rule-key)
+            (str 1 rule-key))
+
+          (instance? java.util.regex.Pattern rule-key)
+          (str 2 rule-key)
+
+          :else
+          (str 3 rule-key)))
+      indents)))
+
+
+(def ^:private clause-skip-matcher
+  "Memoized matcher compiler keyed by indentation rules."
+  (memoize compile-clause-skip-matcher))
+
+
+(defn- resolve-clause-skip-count
+  "Resolve leading argument skip count for a clause-style head.
+
+  Precedence: exact symbol, unqualified symbol, regex pattern, then config map."
+  [head-string skip-matcher clause-form-skips]
+  (let [head-sym (symbol head-string)
+        base-sym (symbol (name head-sym))
+        {:keys [exact unqualified patterns]} skip-matcher]
+    (or
+      (get exact head-sym)
+      (get unqualified base-sym)
+      (some
+        (fn regex-skip
+          [[pattern skip]]
+          (when (re-find pattern head-string)
+            skip))
+        patterns)
+      (get clause-form-skips head-string 0))))
+
+
+(defn- first-alignable-clause-node
+  "Locate the first clause node eligible for clause-style alignment."
+  [zloc skip-matcher clause-form-skips]
+  (let [head-string (-> zloc syntax/first-form-node z/string)
+        skip-count (resolve-clause-skip-count head-string skip-matcher clause-form-skips)]
+    (loop [zloc (-> zloc syntax/first-form-node syntax/next-form-node)
+           skip skip-count]
+      (if (and zloc (pos? skip))
+        (recur (syntax/next-form-node zloc) (dec skip))
+        zloc))))
+
+
+(defn node-alignment-kind
+  "Return the alignment strategy keyword for node, or nil."
+  [zloc rule-config]
+  (cond
+    (and (contains? (:target-set rule-config) :maps)
+         (or (z/map? zloc)
+             (= :namespaced-map (n/tag (z/node zloc)))))
+    :map
+
+    (and (contains? (:target-set rule-config) :bindings)
+         (binding-vector? zloc rule-config))
+    :binding
+
+    (and (contains? (:target-set rule-config) :clauses)
+         (z/list? zloc)
+         (contains? (:clause-form-skips rule-config)
+                    (when-let [head (syntax/first-form-node zloc)]
+                      (z/string head))))
+    :clause
+
+    (and (contains? (:target-set rule-config) :reader-conditionals)
+         (zl/reader-conditional? (z/up zloc))
+         (contains? #{:list :vector :map} (z/tag zloc)))
+    :reader-conditional
+
+    :else
+    nil))
+
+
+(defn- map-alignment-start-node
+  "Return first alignable entry in a map or namespaced map form."
+  [zloc]
+  (if (z/map? zloc)
+    (syntax/first-form-node zloc)
+    (-> zloc
+        z/down
+        (#(z/skip z/right* (complement z/map?) %))
+        syntax/first-form-node)))
+
+
+(defn resolve-start-node-for-kind
+  "Resolve the first alignable node for the selected alignment strategy."
+  [zloc alignment-kind rule-config rules-config]
+  (cond
+    (= :map alignment-kind)
+    (map-alignment-start-node zloc)
+
+    (or (= :binding alignment-kind)
+        (= :reader-conditional alignment-kind))
+    (syntax/first-form-node zloc)
+
+    :else
+    (let [skip-matcher (clause-skip-matcher
+                         (get-in rules-config [:indentation :indents]))
+          clause-form-skips (:clause-form-skips rule-config)]
+      (first-alignable-clause-node zloc skip-matcher clause-form-skips))))

--- a/src/cljstyle/format/align/walk.clj
+++ b/src/cljstyle/format/align/walk.clj
@@ -1,0 +1,188 @@
+(ns cljstyle.format.align.walk
+  "Collect and apply alignment edits by scanning sibling rows."
+  (:require
+    [cljstyle.format.align.continuation :as continuation]
+    [cljstyle.format.align.spacing :as spacing]
+    [cljstyle.format.align.syntax :as syntax]
+    [cljstyle.format.zloc :as zl]
+    [rewrite-clj.zip :as z]))
+
+
+(defn- starts-new-alignment-group?
+  "True if a newline starts a fresh alignment group.
+
+  Blank lines and lines with no substantive content break groups."
+  [newline-loc line-has-content?]
+  (or (> (count (re-seq #"\n" (zl/zstr newline-loc))) 1)
+      (not line-has-content?)))
+
+
+(defn- advance-model-on-newline
+  "Advance scanner state across a newline, resetting row/column as needed."
+  [state newline-loc preserve-prev-on-newline?]
+  (let [{:keys [group-id row-id line-has-content? prev-column prev-cell-id]} state
+        group-break? (starts-new-alignment-group? newline-loc line-has-content?)
+        keep-previous? (and (not group-break?) preserve-prev-on-newline?)]
+    (assoc state
+           :node-loc (z/right* newline-loc)
+           :group-id (if group-break? (inc group-id) group-id)
+           :row-id (if group-break? 0 (inc row-id))
+           :column 0
+           :prev-column (when keep-previous? prev-column)
+           :prev-cell-id (when keep-previous? prev-cell-id)
+           :line-has-content? false)))
+
+
+(defn- register-substantive-cell
+  "Register one substantive node as an alignment cell and advance scanner state."
+  [state node-loc]
+  (let [{:keys [group-id row-id column prev-column prev-cell-id next-cell-id
+                cells! cells-by-column! constraints! max-column-by-group!]} state
+        cell-id next-cell-id
+        start (spacing/start-column node-loc)
+        end (spacing/node-end-position node-loc)
+        left-space-width (spacing/node-left-space-width node-loc)
+        has-left-space? (some? left-space-width)
+        cell {:group-id group-id
+              :row-id row-id
+              :column column
+              :start start
+              :end end
+              :has-left-space? has-left-space?
+              :left-space-width (or left-space-width 0)}
+        cells! (assoc! cells! cell-id cell)
+        column-key [group-id column]
+        cells-by-column! (assoc!
+                           cells-by-column!
+                           column-key
+                           (conj (get cells-by-column! column-key []) cell-id))
+        constraints! (if (some? prev-column)
+                       (let [destination-key [group-id (inc prev-column)]]
+                         (assoc!
+                           constraints!
+                           destination-key
+                           (conj (get constraints! destination-key []) prev-cell-id)))
+                       constraints!)
+        max-column-by-group! (assoc!
+                               max-column-by-group!
+                               group-id
+                               (max column
+                                    (get max-column-by-group! group-id -1)))]
+    (assoc state
+           :node-loc (z/right* node-loc)
+           :column (inc column)
+           :prev-column column
+           :prev-cell-id cell-id
+           :line-has-content? true
+           :next-cell-id (inc next-cell-id)
+           :cells! cells!
+           :cells-by-column! cells-by-column!
+           :constraints! constraints!
+           :max-column-by-group! max-column-by-group!)))
+
+
+(defn collect-alignment-model
+  "Scan nodes into alignment cells and adjacency constraints."
+  [start {:keys [preserve-prev-on-newline?]
+          :or {preserve-prev-on-newline? false}}]
+  (loop [state {:node-loc start
+                :group-id 0
+                :row-id 0
+                :column 0
+                :prev-column nil
+                :prev-cell-id nil
+                :line-has-content? false
+                :next-cell-id 0
+                :cells! (transient {})
+                :cells-by-column! (transient {})
+                :constraints! (transient {})
+                :max-column-by-group! (transient {})}]
+    (if-let [node-loc (:node-loc state)]
+      (cond
+        (zl/space? node-loc)
+        (recur (assoc state :node-loc (z/right* node-loc)))
+
+        (syntax/newline-node? node-loc)
+        (recur (advance-model-on-newline
+                 state
+                 node-loc
+                 preserve-prev-on-newline?))
+
+        (syntax/comma-node? node-loc)
+        (recur (assoc state
+                      :node-loc (z/right* node-loc)
+                      :line-has-content? true))
+
+        (zl/comment? node-loc)
+        (recur (assoc state
+                      :node-loc (z/right* node-loc)
+                      :line-has-content? true))
+
+        :else
+        (recur (register-substantive-cell state node-loc)))
+      {:cells (persistent! (:cells! state))
+       :cells-by-column (persistent! (:cells-by-column! state))
+       :constraints (persistent! (:constraints! state))
+       :max-column-by-group (persistent! (:max-column-by-group! state))})))
+
+
+(defn- apply-node-target-step
+  "Apply one comment or substantive-node alignment step."
+  [state plan indent-comments?]
+  (let [{:keys [node-loc group-id column line-has-content?]} state]
+    (if (zl/comment? node-loc)
+      (let [comment-loc (continuation/maybe-indent-standalone-comment
+                          node-loc
+                          indent-comments?
+                          line-has-content?)]
+        (assoc state
+               :node-loc (z/right* comment-loc)
+               :line-has-content? true
+               :last-loc comment-loc))
+      (let [aligned-node (if-some [target (get plan [group-id column])]
+                           (continuation/pad-node-to-column
+                             node-loc
+                             target
+                             indent-comments?)
+                           node-loc)]
+        (assoc state
+               :node-loc (z/right* aligned-node)
+               :column (inc column)
+               :line-has-content? true
+               :last-loc aligned-node)))))
+
+
+(defn apply-column-targets
+  "Apply precomputed column targets while preserving group boundaries."
+  [start plan {:keys [indent-comments?]}]
+  (loop [state {:node-loc start
+                :group-id 0
+                :column 0
+                :line-has-content? false
+                :last-loc start}]
+    (if-let [node-loc (:node-loc state)]
+      (cond
+        (zl/space? node-loc)
+        (recur (assoc state :node-loc (z/right* node-loc)))
+
+        (syntax/newline-node? node-loc)
+        (let [group-break? (starts-new-alignment-group?
+                             node-loc
+                             (:line-has-content? state))]
+          (recur (assoc state
+                        :node-loc (z/right* node-loc)
+                        :group-id (if group-break?
+                                    (inc (:group-id state))
+                                    (:group-id state))
+                        :column 0
+                        :line-has-content? false
+                        :last-loc node-loc)))
+
+        (syntax/comma-node? node-loc)
+        (recur (assoc state
+                      :node-loc (z/right* node-loc)
+                      :line-has-content? true))
+
+        :else
+        (recur (apply-node-target-step state plan indent-comments?)))
+      (:last-loc state))))

--- a/src/cljstyle/format/core.clj
+++ b/src/cljstyle/format/core.clj
@@ -1,6 +1,7 @@
 (ns cljstyle.format.core
   "Core formatting logic which ties together all rules."
   (:require
+    [cljstyle.format.align :as align]
     [cljstyle.format.comment :as comment]
     [cljstyle.format.fn :as fn]
     [cljstyle.format.indent :as indent]
@@ -59,7 +60,9 @@
   (let [[rule-key sub-key _ edit] rule
         rule-config (get rules-config rule-key)
         start (System/nanoTime)
-        zloc' (zl/safe-edit edit zloc rule-config)
+        zloc' (if (= :align rule-key)
+                (zl/safe-edit edit zloc rule-config rules-config)
+                (zl/safe-edit edit zloc rule-config))
         elapsed (- (System/nanoTime) start)]
     (record-elapsed! durations rule-key sub-key elapsed)
     zloc'))
@@ -105,7 +108,24 @@
 (defn reformat-form
   "Apply formatting rules to the given form."
   [form rules-config]
-  (let [durations (java.util.TreeMap.)]
+  (let [durations (java.util.TreeMap.)
+        apply-indent-and-align-rules
+        (fn [formatted]
+          (if (get-in rules-config [:align :enabled?])
+            (-> formatted
+                (apply-walk-rules
+                  [indent/reindent-lines]
+                  rules-config
+                  durations)
+                (apply-walk-rules
+                  [align/align-columns ws/remove-trailing]
+                  rules-config
+                  durations))
+            (apply-walk-rules
+              formatted
+              [indent/reindent-lines ws/remove-trailing]
+              rules-config
+              durations)))]
     (-> form
         (apply-walk-rules
           [ws/remove-surrounding
@@ -125,11 +145,7 @@
            ns/format-namespaces]
           rules-config
           durations)
-        (apply-walk-rules
-          [indent/reindent-lines
-           ws/remove-trailing]
-          rules-config
-          durations)
+        (apply-indent-and-align-rules)
         (vary-meta assoc ::durations (into {} durations)))))
 
 

--- a/test/cljstyle/config_test.clj
+++ b/test/cljstyle/config_test.clj
@@ -33,6 +33,29 @@
     (is (valid? :cljstyle.config.rules.indentation/indents {'foo [[:block 1]]}))
     (is (valid? :cljstyle.config.rules.indentation/indents {'foo/bar [[:inner 0]]}))
     (is (valid? :cljstyle.config.rules.indentation/indents {#"foo" [[:inner 3]]})))
+  (testing "align"
+    (is (invalid? :cljstyle.config.rules/align nil))
+    (is (invalid? :cljstyle.config.rules/align "align"))
+    (is (invalid? :cljstyle.config.rules/align {:targets [:maps]}))
+    (is (invalid? :cljstyle.config.rules/align {:targets #{:maps :unknown}}))
+    (is (invalid? :cljstyle.config.rules/align {:extra-binding-forms #{"let"}}))
+    (is (invalid? :cljstyle.config.rules/align {:extra-clause-forms ['let]}))
+    (is (invalid? :cljstyle.config.rules/align {:extra-clause-forms {"my-cond" -1}}))
+    (is (invalid? :cljstyle.config.rules/align {:exclude-forms ["case"]}))
+    (is (invalid? :cljstyle.config.rules/align {:indent-comments? :always}))
+    (is (valid? :cljstyle.config.rules/align {:enabled? true}))
+    (is (valid? :cljstyle.config.rules/align {:targets #{:maps :clauses}}))
+    (is (valid? :cljstyle.config.rules/align {:extra-binding-forms ["my-let" "my/let"]}))
+    (is (valid? :cljstyle.config.rules/align {:extra-clause-forms {"my-cond" 0 "my/case-like" 1}}))
+    (is (valid? :cljstyle.config.rules/align {:exclude-forms #{"case" "cond"}}))
+    (is (valid? :cljstyle.config.rules/align {:indent-comments? false}))
+    (is (valid? :cljstyle.config.rules/align
+                {:enabled? true
+                 :targets #{:maps :bindings :clauses :reader-conditionals}
+                 :extra-binding-forms ["my-let" "my/let"]
+                 :extra-clause-forms {"my-cond" 0 "my/case-like" 1}
+                 :exclude-forms #{"case" "cond"}
+                 :indent-comments? true})))
   (testing "file-ignore"
     (is (invalid? :cljstyle.config.files/ignore 123))
     (is (invalid? :cljstyle.config.files/ignore ["foo"]))
@@ -44,8 +67,21 @@
     (is (invalid? ::config/config nil))
     (is (invalid? ::config/config "foo"))
     (is (invalid? ::config/config [123]))
+    (is (invalid? ::config/config {:rules nil}))
+    (is (invalid? ::config/config {:rules "rules"}))
     (is (valid? ::config/config {}))
     (is (valid? ::config/config {:rules {:indentation {:enabled? true}}}))
+    (is (valid? ::config/config
+                {:rules
+                 {:align
+                  {:enabled? true
+                   :targets #{:maps :bindings :clauses :reader-conditionals}
+                   :extra-binding-forms ["my-let" "my/let"]
+                   :extra-clause-forms {"my-cond" 0 "my/case-like" 1}
+                   :exclude-forms #{"case" "cond"}
+                   :indent-comments? true}}}))
+    (is (invalid? ::config/config
+                  {:rules {:align {:targets #{:unknown}}}}))
     (is (valid? ::config/config {:something-else 123}))
     (is (valid? ::config/config config/default-config))))
 

--- a/test/cljstyle/format/align_test.clj
+++ b/test/cljstyle/format/align_test.clj
@@ -1,0 +1,517 @@
+(ns cljstyle.format.align-test
+  (:require
+    [cljstyle.config :as config]
+    [cljstyle.format.align :as align]
+    [cljstyle.format.align.plan :as plan]
+    [cljstyle.format.align.spacing :as spacing]
+    [cljstyle.format.core :as core]
+    [cljstyle.test-util]
+    [clojure.test :refer [are deftest is testing]]
+    [rewrite-clj.node :as n]
+    [rewrite-clj.parser :as parser]
+    [rewrite-clj.zip :as z]))
+
+
+(deftest core-alignment-cases
+  (testing "core alignment behavior"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "{:ram \"warm\"\n :region \"dry\"}"
+      "{:ram    \"warm\"\n :region \"dry\"}"
+
+      {}
+      "(let [ram \"warm\"\n      region \"dry\"]\n  [ram region])"
+      "(let [ram    \"warm\"\n      region \"dry\"]\n  [ram region])"
+
+      {}
+      "(cond\n  done? 1\n  session-expired? 2)"
+      "(cond\n  done?            1\n  session-expired? 2)"
+
+      {}
+      "(cond-> build\n  valid? (emit build)\n  critical? (stream build))"
+      "(cond-> build\n  valid?    (emit build)\n  critical? (stream build))"
+
+      {}
+      "(case action\n  \"scan\" (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+      "(case action\n  \"scan\"  (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+
+      {}
+      "(case kind\n  :brief 1\n  :larger 22\n  (fallback-with-super-long-name kind))"
+      "(case kind\n  :brief  1\n  :larger 22\n  (fallback-with-super-long-name kind))"
+
+      {}
+      "{k node\n :customer-records ctx}"
+      "{k                 node\n :customer-records ctx}"
+
+      {}
+      "(let [k node\n      customer-records ctx])"
+      "(let [k                node\n      customer-records ctx])"
+
+      {}
+      "{:omega 1\n :x 2}"
+      "{:omega 1\n :x     2}"
+
+      {}
+      "(cond compile clean ahead\n      ci test run\n      time fix\n      process phase finish)"
+      "(cond compile clean ahead\n      ci      test  run\n      time    fix\n      process phase finish)"
+
+      {}
+      "{:project {:id :id\n           :domain :east}\n :domain :east}"
+      "{:project {:id     :id\n           :domain :east}\n :domain  :east}"
+
+      {}
+      "{:preview {:bytes 10,\n           :group :ops},\n :records {:bytes 20,\n          :group :dev}}"
+      "{:preview {:bytes 10,\n           :group :ops},\n :records {:bytes 20,\n          :group  :dev}}"
+
+      {}
+      "{:db 1\n\n :memory-pressure 2\n :ttl 3}"
+      "{:db 1\n\n :memory-pressure 2\n :ttl             3}"
+
+      {}
+      "#:acct{:a 1\n :very-long-key 2}"
+      "#:acct{:a       1\n :very-long-key 2}")))
+
+
+(deftest clause-skip-count-cases
+  (testing "clause forms honor skip counts with defaults and comments"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "(condp = status\n  :ok :done\n  ;; keep clause run\n  :retryable :again\n  :unknown)"
+      "(condp = status\n  :ok        :done\n  ;; keep clause run\n  :retryable :again\n  :unknown)"
+
+      {}
+      "(are [input expected]\n  (= (str \"env:\" input) expected)\n  :dev \"env:dev\"\n  :production \"env:production\")"
+      "(are [input expected]\n  (= (str \"env:\" input) expected)\n  :dev        \"env:dev\"\n  :production \"env:production\")")))
+
+
+(deftest reader-conditional-cases
+  (testing "reader conditionals are aligned by default"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "#?(:clj runtime-settings\n   :cljs browser-settings)"
+      "#?(:clj  runtime-settings\n   :cljs browser-settings)"
+
+      {}
+      "#?@(:clj [runtime-key]\n    :cljs [runtime-key])"
+      "#?@(:clj  [runtime-key]\n    :cljs [runtime-key])")))
+
+
+(deftest reader-conditional-nested-cases
+  (testing "nested map branches inside reader conditionals are aligned"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "#?(:clj {:id 1\n         :service-name 2}\n   :cljs {:id 1\n          :service-name 2})"
+      "#?(:clj  {:id           1\n          :service-name 2}\n   :cljs {:id           1\n          :service-name 2})")))
+
+
+(deftest comment-boundary-cases
+  (testing "line comments do not become alignment columns"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "(let [result 1\n      ;; keep group boundary\n      retries 1]\n  retries)"
+      "(let [result  1\n      ;; keep group boundary\n      retries 1]\n  retries)"
+
+      {}
+      "{:result 1\n ;; keep group boundary\n :retries 2}"
+      "{:result  1\n ;; keep group boundary\n :retries 2}"
+
+      {}
+      "(case phase\n  :ok 1\n  ;; keep group boundary\n  :again 2)"
+      "(case phase\n  :ok    1\n  ;; keep group boundary\n  :again 2)")))
+
+
+(deftest comment-indent-option-cases
+  (testing "standalone comments in nested multiline values honor config"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "(let [opts (normalize opts)\n      args [(str opts)\n      ;; Verbose output if enabled.\n            (when verbose?\n              \"--verbose\")]]\n  args)"
+      "(let [opts (normalize opts)\n      args [(str opts)\n            ;; Verbose output if enabled.\n            (when verbose?\n              \"--verbose\")]]\n  args)"
+
+      {:indent-comments? false}
+      "(let [opts (normalize opts)\n      args [(str opts)\n      ;; Verbose output if enabled.\n            (when verbose?\n              \"--verbose\")]]\n  args)"
+      "(let [opts (normalize opts)\n      args [(str opts)\n      ;; Verbose output if enabled.\n            (when verbose?\n              \"--verbose\")]]\n  args)"
+
+      {}
+      "{:opts [(str cfg)\n ;; keep nested comment with value\n        (expand cfg)]}"
+      "{:opts [(str cfg)\n        ;; keep nested comment with value\n        (expand cfg)]}"
+
+      {:indent-comments? false}
+      "{:opts [(str cfg)\n ;; keep nested comment with value\n        (expand cfg)]}"
+      "{:opts [(str cfg)\n ;; keep nested comment with value\n        (expand cfg)]}"))
+  (testing "build-style multiline vectors keep comments aligned with following forms"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "(let [opts (-> opts graal-check graal-uberjar)\n      args [(str (:graal-native-image opts))\n            ;; Verbose output if enabled.\n            (when (:verbose opts)\n              [\"--native-image-info\"\n               \"--verbose\"])\n            ;; Static build flag\n            (when (:graal-static opts)\n              [\"--libc=musl\"\n               ;; see https://github.com/oracle/graal/issues/3398\n               \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n               \"--static\"])]\n      result (b/process {:command-args (remove nil? (flatten args))})]\n  result)"
+      "(let [opts   (-> opts graal-check graal-uberjar)\n      args   [(str (:graal-native-image opts))\n              ;; Verbose output if enabled.\n              (when (:verbose opts)\n                [\"--native-image-info\"\n                 \"--verbose\"])\n              ;; Static build flag\n              (when (:graal-static opts)\n                [\"--libc=musl\"\n                 ;; see https://github.com/oracle/graal/issues/3398\n                 \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n                 \"--static\"])]\n      result (b/process {:command-args (remove nil? (flatten args))})]\n  result)"
+
+      {}
+      "(let [args [(str native-image)\n      ;; Verbose output if enabled.\n            (when verbose?\n              [\"--native-image-info\"\n               \"--verbose\"])\n      ;; Static build flag\n            (when static?\n              [\"--libc=musl\"\n               ;; see issue #3398\n               \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n               \"--static\"])]]\n  args)"
+      "(let [args [(str native-image)\n            ;; Verbose output if enabled.\n            (when verbose?\n              [\"--native-image-info\"\n               \"--verbose\"])\n            ;; Static build flag\n            (when static?\n              [\"--libc=musl\"\n               ;; see issue #3398\n               \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n               \"--static\"])]]\n  args)"
+
+      {:indent-comments? false}
+      "(let [args [(str native-image)\n      ;; Verbose output if enabled.\n            (when verbose?\n              [\"--native-image-info\"\n               \"--verbose\"])\n      ;; Static build flag\n            (when static?\n              [\"--libc=musl\"\n               ;; see issue #3398\n               \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n               \"--static\"])]]\n  args)"
+      "(let [args [(str native-image)\n      ;; Verbose output if enabled.\n            (when verbose?\n              [\"--native-image-info\"\n               \"--verbose\"])\n      ;; Static build flag\n            (when static?\n              [\"--libc=musl\"\n               ;; see issue #3398\n               \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n               \"--static\"])]]\n  args)")))
+
+
+(deftest build-demo-core-pipeline-cases
+  (testing "demo misaligned fixture is normalized end-to-end"
+    (let [rules (-> config/default-config :rules (assoc-in [:align :enabled?] true))
+          misaligned "(let [opts   (-> opts graal-check graal-uberjar)\n      args   [(str (:graal-native-image opts))\n              ;; Verbose output if enabled.\n              (when (:verbose opts)\n                  [\"--native-image-info\"\n                   \"--verbose\"])\n              ;; Static build flag\n              (when (:graal-static opts)\n                  [\"--libc=musl\"\n                 ;; see https://github.com/oracle/graal/issues/3398\n                 \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n                 \"--static\"])]\n      result (b/process {:command-args (remove nil? (flatten args))})]\n  result)"
+          canonical "(let [opts   (-> opts graal-check graal-uberjar)\n      args   [(str (:graal-native-image opts))\n              ;; Verbose output if enabled.\n              (when (:verbose opts)\n                [\"--native-image-info\"\n                 \"--verbose\"])\n              ;; Static build flag\n              (when (:graal-static opts)\n                [\"--libc=musl\"\n                 ;; see https://github.com/oracle/graal/issues/3398\n                 \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n                 \"--static\"])]\n      result (b/process {:command-args (remove nil? (flatten args))})]\n  result)"]
+      (is (= canonical (core/reformat-string misaligned rules)))
+      (is (= canonical (core/reformat-string canonical rules)))))
+  (testing "nested maps in aligned binding vectors keep their own row indentation"
+    (let [rules (-> config/default-config :rules (assoc-in [:align :enabled?] true))
+          source "(def versions\n  \"Map of release and snapshot version strings.\"\n  (let [major   1\n        minor   1\n        patch   {:release  0\n                 :snapshot \"9999-SNAPSHOT\"}]\n    (update-vals patch #(clojure.string/join \".\" [major minor %]))))"
+          expected "(def versions\n  \"Map of release and snapshot version strings.\"\n  (let [major 1\n        minor 1\n        patch {:release  0\n               :snapshot \"9999-SNAPSHOT\"}]\n    (update-vals patch #(clojure.string/join \".\" [major minor %]))))"]
+      (is (= expected (core/reformat-string source rules)))
+      (is (= expected (core/reformat-string expected rules))))))
+
+
+(deftest opener-line-comment-cases
+  (testing "comments immediately after opening delimiters keep original spacing"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "{;; map note\n :a 1\n :very-long 2}"
+      "{;; map note\n :a         1\n :very-long 2}"
+
+      "{ ;; map note\n :a 1\n :very-long 2}"
+      "{ ;; map note\n :a         1\n :very-long 2}"
+
+      "#:acct{;; scoped note\n :a 1\n :very-long 2}"
+      "#:acct{;; scoped note\n :a         1\n :very-long 2}")))
+
+
+(deftest idempotence-cases
+  (testing "first pass reaches canonical form"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "{:ram \"warm\"\n :region \"dry\"}"
+      "{:ram    \"warm\"\n :region \"dry\"}"
+
+      {}
+      "(let [p 1\n      node 2]\n  [p node])"
+      "(let [p    1\n      node 2]\n  [p node])"
+
+      {}
+      "(cond\n  x 1\n  node 2)"
+      "(cond\n  x    1\n  node 2)"))
+  (testing "second pass keeps canonical form unchanged"
+    (are [config formatted]
+         (rule-reformatted? align/align-columns config formatted formatted)
+
+      {}
+      "{:ram    \"warm\"\n :region \"dry\"}"
+
+      {}
+      "(let [p    1\n      node 2]\n  [p node])"
+
+      {}
+      "(cond\n  x    1\n  node 2)"
+
+      {}
+      "(let [opts   (-> opts graal-check graal-uberjar)\n      args   [(str (:graal-native-image opts))\n              ;; Verbose output if enabled.\n              (when (:verbose opts)\n                [\"--native-image-info\"\n                 \"--verbose\"])\n              ;; Static build flag\n              (when (:graal-static opts)\n                [\"--libc=musl\"\n                 ;; see https://github.com/oracle/graal/issues/3398\n                 \"-H:CCompilerOption=-Wl,-z,stack-size=2097152\"\n                 \"--static\"])]\n      result (b/process {:command-args (remove nil? (flatten args))})]\n  result)")))
+
+
+(deftest space-shrinking-cases
+  (testing "extra spaces are normalized without merging tokens"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "{:k          1\n :node 2}"
+      "{:k    1\n :node 2}"
+
+      "(let [k          1\n      node 2]\n  [k node])"
+      "(let [k    1\n      node 2]\n  [k node])"
+
+      "(cond\n  k          1\n  node 2)"
+      "(cond\n  k    1\n  node 2)")))
+
+
+(deftest custom-form-config-cases
+  (testing "custom form names can opt into alignment"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {}
+      "(bind-x [k 1\n         node 2]\n  [k node])"
+      "(bind-x [k 1\n         node 2]\n  [k node])"
+
+      {:extra-binding-forms ["bind-x"]}
+      "(bind-x [k 1\n         node 2]\n  [k node])"
+      "(bind-x [k    1\n         node 2]\n  [k node])"
+
+      {}
+      "(switchy\n  k 1\n  node 2)"
+      "(switchy\n  k 1\n  node 2)"
+
+      {:extra-clause-forms {"switchy" 0 "demo/switchy" 0}}
+      "(switchy\n  k 1\n  node 2)"
+      "(switchy\n  k    1\n  node 2)"
+
+      {:extra-clause-forms {"switchy" 0 "demo/switchy" 0}}
+      "(demo/switchy\n  k 1\n  node 2)"
+      "(demo/switchy\n  k    1\n  node 2)"))
+  (testing "targets can narrow which structures are aligned"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {:targets #{:bindings}}
+      "{:ram \"warm\"\n :region \"dry\"}"
+      "{:ram \"warm\"\n :region \"dry\"}"
+
+      {:targets #{:maps}}
+      "(let [ram \"warm\"\n      region \"dry\"]\n  [ram region])"
+      "(let [ram \"warm\"\n      region \"dry\"]\n  [ram region])")))
+
+
+(deftest custom-form-exclusion-precedence-cases
+  (testing "excluded forms bypass built-ins and custom form config"
+    (are [config source expected]
+         (rule-reformatted? align/align-columns config source expected)
+
+      {:exclude-forms #{"case"}}
+      "(case action\n  \"scan\" (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+      "(case action\n  \"scan\" (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+
+      {:extra-clause-forms {"switchy" 0}
+       :exclude-forms #{"switchy"}}
+      "(switchy\n  k 1\n  node 2)"
+      "(switchy\n  k 1\n  node 2)")))
+
+
+(deftest metadata-target-cases
+  (testing "alignment still applies to metadata-wrapped maps"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "^{:doc true} {:k 1\n             :name 2}"
+      "^{:doc true} {:k   1\n             :name 2}"
+
+      "{:env ^:legacy {:k 1\n                 :name 2}\n :id 1}"
+      "{:env ^:legacy {:k     1\n                 :name 2}\n :id  1}")))
+
+
+(deftest comma-heavy-cases
+  (testing "commas around aligned forms are preserved"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "{:k, 1,\n :node, 2}"
+      "{:k,    1,\n :node, 2}"
+
+      "(let [k, 1,\n      node, 2]\n  [k node])"
+      "(let [k,    1,\n      node, 2]\n  [k node])"
+
+      "(cond\n  k, 1,\n  node, 2)"
+      "(cond\n  k,    1,\n  node, 2)"
+
+      "{:meta \"^\", :meta* \"#^\", :vector \"[\", :map \"{\"\n :list \"(\", :eval \"#=\", :uneval \"#_\", :fn \"#(\"\n :set \"#{\", :deref \"@\", :reader-macro \"#\", :unquote \"~\"\n :var \"#'\", :quote \"'\", :syntax-quote \"`\", :unquote-splicing \"~@\",\n :namespaced-map \"#\"}"
+      "{:meta           \"^\",  :meta* \"#^\", :vector       \"[\",  :map              \"{\"\n :list           \"(\",  :eval  \"#=\", :uneval       \"#_\", :fn               \"#(\"\n :set            \"#{\", :deref \"@\",  :reader-macro \"#\",  :unquote          \"~\"\n :var            \"#'\", :quote \"'\",  :syntax-quote \"`\",  :unquote-splicing \"~@\",\n :namespaced-map \"#\"}")))
+
+
+(deftest multiline-pair-layout-cases
+  (testing "multi-line key/value rows are left unchanged"
+    (are [config source]
+         (rule-reformatted? align/align-columns config source source)
+
+      {}
+      "{:left\n :alpha\n\n :right\n :beta}"
+
+      {}
+      "(let [left\n      :alpha\n\n      right\n      :beta])"
+
+      {}
+      "{:source\n 1\n\n :very-verbose-symbol\n 2\n\n :id\n 3}"
+
+      {}
+      "(let [source\n      1\n\n      very-verbose-symbol\n      2\n\n      id\n      3])"
+
+      {}
+      "{:left\n ;; keep split layout\n :alpha\n\n :right\n :beta}"
+
+      {}
+      "(let [durations (java.util.TreeMap.)\n      apply-indent-and-align-rules\n      (fn [formatted]\n        formatted)])")))
+
+
+(deftest non-target-safety-cases
+  (testing "forms outside alignment targets remain unchanged"
+    (are [source]
+         (rule-reformatted? align/align-columns {} source source)
+
+      "[:k 1\n :node 2]"
+      "(do\n  k 1\n  node 2)"
+      "#{:k 1 :node 2}")))
+
+
+(deftest namespaced-map-variant-cases
+  (testing "namespaced map variants align value columns"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "#::{:id 1\n    :service-name 2}"
+      "#::{:id           1\n    :service-name 2}"
+
+      "^:legacy #::{:id 1\n             :service-name 2}"
+      "^:legacy #::{:id           1\n             :service-name 2}")))
+
+
+(deftest qualified-clause-form-cases
+  (testing "qualified clause forms align like unqualified built-ins"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "(clojure.core/cond\n  done? 1\n  session-expired? 2)"
+      "(clojure.core/cond\n  done?            1\n  session-expired? 2)"
+
+      "(clojure.core/case action\n  \"scan\" (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+      "(clojure.core/case action\n  \"scan\"  (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))"
+
+      "(cljs.core/cond-> build\n  valid? (emit build)\n  critical? (stream build))"
+      "(cljs.core/cond-> build\n  valid?    (emit build)\n  critical? (stream build))")))
+
+
+(deftest mixed-form-snapshot-cases
+  (testing "mixed forms align together when targets are enabled"
+    (let [source "(let [ram \"warm\"\n      region \"dry\"]\n  [ram region])\n\n{:id 1\n :service-name 2}\n\n(clojure.core/case action\n  \"scan\" (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))\n\n#?(:clj runtime-settings\n   :cljs browser-settings)"]
+      (are [config expected]
+           (rule-reformatted? align/align-columns config source expected)
+
+        {}
+        "(let [ram    \"warm\"\n      region \"dry\"]\n  [ram region])\n\n{:id           1\n :service-name 2}\n\n(clojure.core/case action\n  \"scan\"  (scan/print-usage)\n  \"audit\" (audit/print-usage)\n  (print-action-usage summary))\n\n#?(:clj  runtime-settings\n   :cljs browser-settings)"
+
+        {:targets #{}}
+        source))))
+
+
+(deftest non-target-lookalike-cases
+  (testing "pair-like vectors remain unchanged"
+    (are [source]
+         (rule-reformatted? align/align-columns {} source source)
+
+      "[:id 1\n :service-name 2]"
+      "[:id 1\n ;; keep vector row comment\n :service-name 2]"
+      "[:id 1\n\n :service-name 2]")))
+
+
+(deftest edge-noop-cases
+  (testing "edge shapes stay stable while still exercising align walks"
+    (are [config source]
+         (rule-reformatted? align/align-columns config source source)
+
+      {}
+      "{}"
+
+      {}
+      "#:acct{}"
+
+      {}
+      "()"
+
+      {}
+      "(condp)"
+
+      {}
+      "(let\n  [aa, 1\n   ;; keep line\n   bb, 2])"
+
+      {:indent-comments? false}
+      "{:a 1\n ;; keep standalone\n :b 2}"
+
+      {}
+      "{:a 1\n ;; trailing note\n}")))
+
+
+(deftest multiline-continuation-edge-cases
+  (testing "multiline value continuations handle trailing and blank lines safely"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "{:a [1\n]\n :very-long-key 2}"
+      "{:a             [1\n]\n :very-long-key 2}"
+
+      "{:a [1\n   ]\n :very-long-key 2}"
+      "{:a             [1\n               ]\n :very-long-key 2}"
+
+      "{:a [\n]\n :very-long-key 2}"
+      "{:a             [\n]\n :very-long-key 2}"
+
+      "{:a [1\n,2]\n :very-long-key 3}"
+      "{:a             [1\n            ,2]\n :very-long-key 3}"
+
+      "{:a [a ;; note\n     b]\n :very-long-key 2}"
+      "{:a             [a ;; note\n                 b]\n :very-long-key 2}"
+
+      "{:a [\"a\nx\" ;; note\n     y]\n :very-long-key 2}"
+      "{:a             [\"a\nx\"               ;; note\n                 y]\n :very-long-key 2}"
+
+      "{:a [(foo x)\n  (bar x)]\n :very-long-key 2}"
+      "{:a             [(foo x)\n              (bar x)]\n :very-long-key 2}"
+
+      "{:a [(foo x)\n     (bar x)]\n :very-long-key 2}"
+      "{:a             [(foo x)\n                 (bar x)]\n :very-long-key 2}"
+
+      "{:a [a\n     bb\n   ccc]\n :very-long-key 2}"
+      "{:a             [a\n                 bb\n                 ccc]\n :very-long-key 2}"
+
+      "{:a [1\n ;; lone comment\n]\n :very-long-key 2}"
+      "{:a             [1\n             ;; lone comment\n]\n :very-long-key 2}"))
+  (testing "trailing standalone comments keep alignment and closing delimiter spacing"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "{:a 1\n ;; trailing only\n}"
+      "{:a 1\n ;; trailing only\n}")))
+
+
+(deftest clause-inline-comment-continuation-cases
+  (testing "clause rows with multiline predicates and inline comments are deterministic"
+    (are [source expected]
+         (rule-reformatted? align/align-columns {} source expected)
+
+      "(cond\n  \"a\nx\" ;; note\n  y\n  long-name 2)"
+      "(cond\n  \"a\nx\" ;; note\n            y\n  long-name 2)"
+
+      "(case kind\n  \"a\nx\" ;; note\n  [v]\n  long-name [w]\n  :fallback)"
+      "(case kind\n  \"a\nx\" ;; note\n            [v]\n  long-name [w]\n  :fallback)")))
+
+
+(deftest planner-defensive-column-gap-cases
+  (testing "planner skips unconstrained destination columns and continues"
+    (is (= {[:g 2] 3}
+           (plan/plan-column-targets
+             {:cells {:src {:row-id :row-1
+                            :end 2}
+                      :dst {:row-id :row-1
+                            :start 4
+                            :has-left-space? true
+                            :left-space-width 1}}
+              :cells-by-column {[:g 2] [:dst]}
+              :constraints {[:g 2] [:src]}
+              :max-column-by-group {:g 2}})))))
+
+
+(deftest spacing-edge-cases
+  (testing "line-start nodes without left whitespace ignore negative spacing deltas"
+    (let [root (z/edn* (parser/parse-string-all "[a\nb]") {:track-position? true})
+          line-start (-> root z/down z/down z/right* z/right*)]
+      (is (= "[a\nb]"
+             (-> (spacing/adjust-left-spacing line-start -1)
+                 z/root
+                 n/string))))))

--- a/test/cljstyle/format/core_test.clj
+++ b/test/cljstyle/format/core_test.clj
@@ -192,6 +192,84 @@
         "(defelem foo [x]\n  [:foo x])")))
 
 
+(deftest aligned-forms
+  (let [align-rules (assoc-in default-rules [:align :enabled?] true)
+        align-override-rules (assoc-in align-rules [:indentation :indents 'cond->] [[:inner 0]])
+        align-numeric-indent-method-rules (-> align-rules
+                                              (assoc-in [:indentation :enabled?] false)
+                                              (assoc-in [:indentation :indents 'odd-case] [1]))
+        align-custom-clause-rules (-> align-rules
+                                      (update-in
+                                        [:align :extra-clause-forms]
+                                        merge
+                                        {"switcher" 0
+                                         "demo/switcher" 0
+                                         "regex-switch" 0})
+                                      (update-in
+                                        [:indentation :indents]
+                                        merge
+                                        {'demo/switcher [[:inner 1]]
+                                         'switcher [[:inner 1]]
+                                         #"^regex-switch$" [[:inner 1]]
+                                         :ignore-me [[:inner 0]]}))]
+    (is (reformatted?
+          fmt/reformat-form default-rules
+          "(let [path \"deps\"\n      profile \"tool\"]\n  [path profile])"
+          "(let [path \"deps\"\n      profile \"tool\"]\n  [path profile])"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "(let [path \"deps\"\n      profile \"tool\"]\n  [path profile])"
+          "(let [path    \"deps\"\n      profile \"tool\"]\n  [path profile])"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "{:path \"deps\"\n :profile \"tool\"}"
+          "{:path    \"deps\"\n :profile \"tool\"}"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "(cond-> compile-mode\n  a 1\n  bb 2)"
+          "(cond-> compile-mode\n  a  1\n  bb 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-override-rules
+          "(cond-> compile-mode\n  a 1\n  bb 2)"
+          "(cond-> compile-mode\n  a                  1\n  bb                 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-custom-clause-rules
+          "(switcher base\n  a 1\n  bb 2)"
+          "(switcher base\n          a  1\n          bb 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-custom-clause-rules
+          "(demo/switcher base\n  a 1\n  bb 2)"
+          "(demo/switcher base\n               a  1\n               bb 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-custom-clause-rules
+          "(regex-switch base\n  a 1\n  bb 2)"
+          "(regex-switch base\n              a  1\n              bb 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-numeric-indent-method-rules
+          "(cond\n  a 1\n  bb 2)"
+          "(cond\n  a  1\n  bb 2)"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "{:c [(str base)\n\n     (emit base)]\n :long-key 1}"
+          "{:c        [(str base)\n\n            (emit base)]\n :long-key 1}"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "{:a 1 ;; inline\n :long-key 2}"
+          "{:a 1 ; inline\n      :long-key 2}"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "{:a 1\n ;; trailing\n}"
+          "{:a 1\n ;; trailing\n }"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "#?(:clj :server\n   :cljs :browser)"
+          "#?(:clj  :server\n   :cljs :browser)"))
+    (is (reformatted?
+          fmt/reformat-form align-rules
+          "(do ())"
+          "(do ())"))))
+
+
 (deftest eof-newlines
   (is (= ":x" (fmt/reformat-file ":x" (assoc-in default-rules [:eof-newline :enabled?] false))))
   (is (= ":x\n\n\n" (fmt/reformat-file ":x\n\n\n" (assoc-in default-rules [:eof-newline :enabled?] false))))


### PR DESCRIPTION
Fixes #47.

This introduces a new `:align` formatting rule for projects that prefer vertical column alignment in associative forms. The rule is disabled by default, so existing formatting behavior is unchanged unless a project opts in.

The implementation lives under `src/cljstyle/format/align/*` and follows a structured pipeline: walk blank-line groups, build an alignment model, plan column targets, and apply spacing edits. The rule covers maps, let-like binding vectors, clause-style forms, and reader conditionals. Projects can tune behavior with `:targets`, `:extra-binding-forms`, `:extra-clause-forms`, and `:exclude-forms`.

Comment and continuation handling received focused treatment so alignment stays predictable in real code. Standalone comments are not treated as alignment columns, opener-line comments keep their spacing, and `:indent-comments?` (default `true`) controls whether standalone comments follow the next substantive line in multiline groups.

`reformat-form` now runs alignment as an explicit opt-in pass after indentation, followed by trailing-whitespace cleanup, which keeps target-column planning stable across repeated runs.

Configuration support was extended in `src/cljstyle/config.clj`, and docs were updated in `doc/configuration.md` and `README.md` to show defaults and opt-in usage.

Test coverage was expanded in `test/cljstyle/format/align_test.clj`, with additional integration and config validation in `test/cljstyle/format/core_test.clj` and `test/cljstyle/config_test.clj`, including cases for custom forms, reader conditionals, continuation/comment placement, blank-line boundaries, and idempotence.

Also add common macOS artifacts to `.gitignore`.
